### PR TITLE
Add FormatManager to base library

### DIFF
--- a/PCGen-base/code/src/java/pcgen/base/format/ArrayFormatManager.java
+++ b/PCGen-base/code/src/java/pcgen/base/format/ArrayFormatManager.java
@@ -92,7 +92,12 @@ public class ArrayFormatManager<T> implements FormatManager<T[]>
 			T[] toSet = (T[]) Array.newInstance(componentClass, 0);
 			return toSet;
 		}
-		// TODO Check for illegal commas...
+		if (!hasValidSeparators(instructions))
+		{
+			throw new IllegalArgumentException(
+				"Poorly formatted instructions (bad separator location): "
+					+ instructions);
+		}
 		String[] items = instructions.split(Character.toString(separator));
 		@SuppressWarnings("unchecked")
 		T[] toSet = (T[]) Array.newInstance(componentClass, items.length);
@@ -102,6 +107,14 @@ public class ArrayFormatManager<T> implements FormatManager<T[]>
 			toSet[i] = obj;
 		}
 		return toSet;
+	}
+
+	private boolean hasValidSeparators(String value)
+	{
+		//assume not empty due to checks on instructions
+		return (value.charAt(0) != separator)
+			&& (value.charAt(value.length() - 1) != separator)
+			&& (value.indexOf(String.valueOf(new char[]{separator, separator})) == -1);
 	}
 
 	/**
@@ -131,7 +144,12 @@ public class ArrayFormatManager<T> implements FormatManager<T[]>
 					(Indirect<T>[]) Array.newInstance(Indirect.class, 0);
 			return new ArrayIndirect(toSet);
 		}
-		// TODO Check for illegal commas...
+		if (!hasValidSeparators(instructions))
+		{
+			throw new IllegalArgumentException(
+				"Poorly formatted instructions (bad separator location): "
+					+ instructions);
+		}
 		String[] items = instructions.split(Character.toString(separator));
 		@SuppressWarnings("unchecked")
 		Indirect<T>[] toSet =

--- a/PCGen-base/code/src/java/pcgen/base/formatmanager/ArrayFormatFactory.java
+++ b/PCGen-base/code/src/java/pcgen/base/formatmanager/ArrayFormatFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.formatmanager;
+
+import java.util.regex.Pattern;
+
+import pcgen.base.format.ArrayFormatManager;
+import pcgen.base.util.FormatManager;
+
+/**
+ * An ArrayFormatFactory builds a FormatManager supporting Arrays from the name
+ * of the format of the component of the Array
+ */
+public class ArrayFormatFactory implements FormatManagerFactory
+{
+
+	/**
+	 * A pattern to ensure no multidimensional arrays
+	 */
+	private static final Pattern ARRAY_PATTERN = Pattern.compile(
+		Pattern.quote("ARRAY["), Pattern.CASE_INSENSITIVE);
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public FormatManager<?> build(String subFormatName,
+		FormatManagerLibrary library)
+	{
+		if (subFormatName == null)
+		{
+			throw new IllegalArgumentException(
+				"Array Format cannot be built from no instructions");
+		}
+		if (ARRAY_PATTERN.matcher(subFormatName).find())
+		{
+			/*
+			 * This is currently prohibited because - among other things -
+			 * ArrayFormatManager has no way to convert a multi-dimensional
+			 * array
+			 */
+			throw new IllegalArgumentException(
+				"Multidimensional Array format not supported: " + subFormatName
+					+ " may not contain brackets");
+		}
+		return new ArrayFormatManager<>(
+			library.getFormatManager(subFormatName), ',');
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String getBuilderBaseFormat()
+	{
+		return "ARRAY";
+	}
+
+}

--- a/PCGen-base/code/src/java/pcgen/base/formatmanager/FormatManagerFactory.java
+++ b/PCGen-base/code/src/java/pcgen/base/formatmanager/FormatManagerFactory.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.formatmanager;
+
+import pcgen.base.util.FormatManager;
+
+/**
+ * A FormatManagerFactory converts strings identifying a Format into the
+ * appropriate FormatManager.
+ * 
+ * For compound / complex formats (e.g. ARRAY) it is expected that there is one
+ * FormatManagerFactory to handle all of those scenarios (since they can be
+ * composed from the "native" FormatMangaer objects.
+ */
+public interface FormatManagerFactory
+{
+
+	/**
+	 * Returns the FormatManager for the given format name based on the contents
+	 * of the given FormatManagerLibrary.
+	 * 
+	 * @param formatName
+	 *            The name of the format for which the FormatManager will be
+	 *            returned
+	 * @param library
+	 *            The FormatManagerLibrary used to store valid FormatManager
+	 *            objects
+	 * @return The FormatManager for the given format name based on the contents
+	 *         of the given FormatManagerLibrary
+	 */
+	public FormatManager<?> build(String formatName,
+		FormatManagerLibrary library);
+
+	/**
+	 * Returns the first level format of the FormatManager this
+	 * FormatManagerFactory produces.
+	 * 
+	 * If this FormatManagerFactory produces "native" FormatManager objects
+	 * (e.g. for Number.class or String.class) then this value should match the
+	 * format name (NUMBER or STRING, respectively). If this
+	 * FormatManagerFactory returns a complex / compound object, then this
+	 * should return the name of the immediate class created by the
+	 * FormatManager.
+	 * 
+	 * For example, if the FormatManager produces ARRAY[x], then this should
+	 * return "ARRAY", not ARRAY[STRING] or any specific value. In theory this
+	 * should therefore correlate in a 1:1 fashion (though not as literal
+	 * strings) with the response to .getClass().getName() on an item returned
+	 * by a FormatManager returned by this FormatManagerFactory.
+	 * 
+	 * Said another way, the response to this method ignores .getComponentType()
+	 * on an array class if such would be returned by a FormatManager returned
+	 * by this FormatManagerFactory.
+	 * 
+	 * @return The first level format of the FormatManager this
+	 *         FormatManagerFactory produces
+	 */
+	public String getBuilderBaseFormat();
+
+}

--- a/PCGen-base/code/src/java/pcgen/base/formatmanager/FormatManagerLibrary.java
+++ b/PCGen-base/code/src/java/pcgen/base/formatmanager/FormatManagerLibrary.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.formatmanager;
+
+import pcgen.base.util.FormatManager;
+
+/**
+ * A FormatManagerLibrary can return a FormatManager given a Format name.
+ */
+public interface FormatManagerLibrary
+{
+	/**
+	 * Returns a FormatManager for the format identified by the given Format
+	 * name.
+	 * 
+	 * @param formatName
+	 *            The Format name for which the FormatManager should be returned
+	 * @return A FormatManager for the format identified by the given Format
+	 *         name
+	 */
+	public FormatManager<?> getFormatManager(String formatName);
+}

--- a/PCGen-base/code/src/java/pcgen/base/formatmanager/FormatManagerLibraryUtilities.java
+++ b/PCGen-base/code/src/java/pcgen/base/formatmanager/FormatManagerLibraryUtilities.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.formatmanager;
+
+import pcgen.base.format.BooleanManager;
+import pcgen.base.format.NumberManager;
+import pcgen.base.format.OrderedPairManager;
+import pcgen.base.format.StringManager;
+
+/**
+ * FormatManagerLibraryUtilities are utility methods for FormatManagerLibrary
+ * objects.
+ */
+public class FormatManagerLibraryUtilities
+{
+
+	private FormatManagerLibraryUtilities()
+	{
+		//Don't construct utility class
+	}
+
+	/**
+	 * Initializes the given SimpleFormatManagerLibrary with the known
+	 * FormatManager / FormatManagerFactory objects in the base library.
+	 * 
+	 * @param library
+	 *            The SimpleFormatManagerLibrary to be loaded with the known
+	 *            FormatManager / FormatManagerFactory objects
+	 */
+	public static void loadDefaultFormats(SimpleFormatManagerLibrary library)
+	{
+		library.addFormatManager(new NumberManager());
+		library.addFormatManager(new StringManager());
+		library.addFormatManager(new BooleanManager());
+		library.addFormatManager(new OrderedPairManager());
+		library.addFormatManagerBuilder(new ArrayFormatFactory());
+	}
+}

--- a/PCGen-base/code/src/java/pcgen/base/formatmanager/FormatManagerWrapper.java
+++ b/PCGen-base/code/src/java/pcgen/base/formatmanager/FormatManagerWrapper.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2016 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.formatmanager;
+
+import pcgen.base.util.FormatManager;
+
+/**
+ * A FormatManagerWrapper is a decorator to convert a FormatManager into a
+ * FormatManagerFactory.
+ */
+public class FormatManagerWrapper implements FormatManagerFactory
+{
+	/**
+	 * The underlying FormatManager.
+	 */
+	private final FormatManager<?> formatManager;
+
+	/**
+	 * Constructs a new FormatManagerWrapper for the given FormatManager.
+	 * 
+	 * @param fmtManager
+	 *            The underlying FormatManager for this FormatManagerWrapper
+	 * @throws IllegalArgumentException
+	 *             if the given FormatManager has no identifier type or if the
+	 *             given FormatManager has no managed class
+	 */
+	public FormatManagerWrapper(FormatManager<?> fmtManager)
+	{
+		String fmIdent = fmtManager.getIdentifierType();
+		if (fmIdent == null)
+		{
+			throw new IllegalArgumentException(
+				"Cannot use a FormatManager with no identifier (was nominally for: "
+					+ fmtManager.getManagedClass() + ")");
+		}
+		Class<?> fmFormat = fmtManager.getManagedClass();
+		if (fmFormat == null)
+		{
+			throw new IllegalArgumentException(
+				"Cannot use a FormatManager with no format (was nominally for: "
+					+ fmFormat + ")");
+		}
+		formatManager = fmtManager;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public FormatManager<?> build(String formatSub, FormatManagerLibrary library)
+	{
+		if (formatSub == null)
+		{
+			return formatManager;
+		}
+		throw new IllegalArgumentException("Format: "
+			+ formatManager.getIdentifierType()
+			+ " may not contain a subformat");
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String getBuilderBaseFormat()
+	{
+		return formatManager.getIdentifierType();
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return formatManager.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj)
+	{
+		return (obj instanceof FormatManagerWrapper)
+			&& formatManager.equals(((FormatManagerWrapper) obj).formatManager);
+	}
+
+}

--- a/PCGen-base/code/src/java/pcgen/base/formatmanager/SimpleFormatManagerLibrary.java
+++ b/PCGen-base/code/src/java/pcgen/base/formatmanager/SimpleFormatManagerLibrary.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2016 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.formatmanager;
+
+import pcgen.base.util.CaseInsensitiveMap;
+import pcgen.base.util.FormatManager;
+
+/**
+ * A SimpleFormatManagerLibrary stores FormatManagers that can be used and can
+ * build compound formats by using FormatManagerFactory objects. Formats are
+ * stored by their identifier String (e.g. "STRING" for StringManager).
+ */
+public final class SimpleFormatManagerLibrary implements FormatManagerLibrary
+{
+
+	/**
+	 * A Map storing the FormatManagerBuilders by (case-insensitive) name
+	 */
+	private CaseInsensitiveMap<FormatManagerFactory> builderByIdentifier =
+			new CaseInsensitiveMap<FormatManagerFactory>();
+
+	/**
+	 * Gets the FormatManager for the given String identifying a format of
+	 * object.
+	 * 
+	 * @param formatName
+	 *            The String identifying the format for which the FormatManager
+	 *            should be returned
+	 * @return The FormatManager for the given String identifying a format of
+	 *         object
+	 * @throws IllegalArgumentException
+	 *             if the given format does not have an associated FormatManager
+	 */
+	@Override
+	public FormatManager<?> getFormatManager(String formatName)
+	{
+		FormatManagerFactory fmtManagerBuilder =
+				builderByIdentifier.get(formatName);
+		String formatSub = null;
+		if (fmtManagerBuilder == null)
+		{
+			int sqBracketLoc = formatName.indexOf("[");
+			if (sqBracketLoc != -1)
+			{
+				int lengthMinusOne = formatName.length() - 1;
+				if (formatName.indexOf("]") != lengthMinusOne)
+				{
+					throw new IllegalArgumentException(
+						"Format Name must have matching open and close brackets, found: "
+							+ formatName);
+				}
+				String formatRoot = formatName.substring(0, sqBracketLoc);
+				formatSub =
+						formatName.substring(sqBracketLoc + 1, lengthMinusOne);
+				fmtManagerBuilder = builderByIdentifier.get(formatRoot);
+			}
+			if (fmtManagerBuilder == null)
+			{
+				throw new IllegalArgumentException(
+					"No FormatManager available for " + formatName);
+			}
+		}
+		return fmtManagerBuilder.build(formatSub, this);
+	}
+
+	/**
+	 * Adds a FormatManager to the FormatManagerLibrary.
+	 * 
+	 * @param fmtManager
+	 *            The FormatManager to be added to this FormatManagerLibrary
+	 * @throws IllegalArgumentException
+	 *             if this FormatManagerLibrary already has a
+	 *             FormatManagerBuilder with a matching identifier
+	 */
+	public void addFormatManager(FormatManager<?> fmtManager)
+	{
+		addFormatManagerBuilder(new FormatManagerWrapper(fmtManager));
+	}
+
+	/**
+	 * Adds a FormatManagerBuilder to the FormatManagerLibrary.
+	 * 
+	 * @param Builder
+	 *            The FormatManagerBuilder to be added to this
+	 *            FormatManagerLibrary
+	 * @throws IllegalArgumentException
+	 *             if this FormatManagerLibrary already has a
+	 *             FormatManagerBuilder with a matching identifier
+	 */
+	public void addFormatManagerBuilder(FormatManagerFactory builder)
+	{
+		String fmIdent = builder.getBuilderBaseFormat();
+		FormatManagerFactory byIdentifier = builderByIdentifier.get(fmIdent);
+		if ((byIdentifier != null) && !byIdentifier.equals(builder))
+		{
+			throw new IllegalArgumentException(
+				"Cannot set another Format Manager Builder for " + fmIdent);
+		}
+		builderByIdentifier.put(fmIdent, builder);
+	}
+}

--- a/PCGen-base/code/src/test/pcgen/base/format/ArrayFormatManagerTest.java
+++ b/PCGen-base/code/src/test/pcgen/base/format/ArrayFormatManagerTest.java
@@ -31,7 +31,7 @@ public class ArrayFormatManagerTest extends TestCase
 	private ArrayFormatManager<Number> manager = new ArrayFormatManager<>(
 		new NumberManager(), ',');
 
-	public void testConnstructor()
+	public void testConstructor()
 	{
 		try
 		{
@@ -87,6 +87,68 @@ public class ArrayFormatManagerTest extends TestCase
 		}
 	}
 
+	public void testConvertIndirectFailBadSeparator()
+	{
+		try
+		{
+			manager.convertIndirect(",4,6");
+			fail("starting comma value should fail");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//ok as well
+		}
+		try
+		{
+			manager.convertIndirect("4,5,");
+			fail("endign comma value should fail");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//ok as well
+		}
+		try
+		{
+			manager.convertIndirect("3,4,,5");
+			fail("doublecomma value should fail");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//ok as well
+		}
+	}
+
+	public void testConvertFailBadSeparator()
+	{
+		try
+		{
+			manager.convert(",4,6");
+			fail("starting comma value should fail");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//ok as well
+		}
+		try
+		{
+			manager.convert("4,5,");
+			fail("endign comma value should fail");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//ok as well
+		}
+		try
+		{
+			manager.convert("3,4,,5");
+			fail("doublecomma value should fail");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//ok as well
+		}
+	}
+
 	public void testConvert()
 	{
 		assertTrue(Arrays.equals(new Number[]{}, manager.convert(null)));
@@ -107,6 +169,8 @@ public class ArrayFormatManagerTest extends TestCase
 		assertEquals("-3,4.1,5", manager.unconvert(ARR_N3_4P1_5));
 		//Just to show it's not picky
 		assertEquals("1.4", manager.unconvert(new Double[]{Double.valueOf(1.4)}));
+		assertTrue(Arrays.equals(new Number[]{}, manager.convert(null)));
+		assertTrue(Arrays.equals(new Number[]{}, manager.convert("")));
 	}
 
 	public void testConvertIndirect()

--- a/PCGen-base/code/src/test/pcgen/base/formatmanager/ArrayFormatFactoryTest.java
+++ b/PCGen-base/code/src/test/pcgen/base/formatmanager/ArrayFormatFactoryTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2014 Tom Parker <thpr@users.sourceforge.net> This program is
+ * free software; you can redistribute it and/or modify it under the terms of
+ * the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 2.1 of the License, or (at your option) any later
+ * version.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+package pcgen.base.formatmanager;
+
+import java.util.Arrays;
+
+import junit.framework.TestCase;
+import pcgen.base.format.NumberManager;
+import pcgen.base.format.StringManager;
+import pcgen.base.util.FormatManager;
+
+public class ArrayFormatFactoryTest extends TestCase
+{
+	private static final Number[] ARR_N3_4_5 = new Number[]{
+		Integer.valueOf(-3), Integer.valueOf(4), Integer.valueOf(5)};
+	private static final Number[] ARR_N3_4P1_5 = new Number[]{
+		Integer.valueOf(-3), Double.valueOf(4.1), Integer.valueOf(5)};
+	private static final Number[] ARR_1P4 = new Number[]{Double.valueOf(1.4)};
+	private static final Number[] ARR_N3 = new Number[]{Integer.valueOf(-3)};
+	private static final Number[] ARR_1 = new Number[]{Integer.valueOf(1)};
+
+	private SimpleFormatManagerLibrary library;
+	private ArrayFormatFactory factory;
+
+	@Override
+	protected void setUp() throws Exception
+	{
+		super.setUp();
+		library = new SimpleFormatManagerLibrary();
+		FormatManagerLibraryUtilities.loadDefaultFormats(library);
+		factory = new ArrayFormatFactory();
+	}
+
+	public void testFailBadSubFormat()
+	{
+		try
+		{
+			factory.build("NUM", library);
+			fail("bad sub form should fail");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//ok as well
+		}
+	}
+
+	public void testFailNullSubFormat()
+	{
+		try
+		{
+			factory.build(null, library);
+			fail("null sub form should fail");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//ok as well
+		}
+	}
+
+	public void testConvert()
+	{
+		FormatManager<Number[]> manager =
+				(FormatManager<Number[]>) factory.build("NUMBER", library);
+		assertTrue(Arrays.equals(new Number[]{}, manager.convert(null)));
+		assertTrue(Arrays.equals(new Number[]{}, manager.convert("")));
+		assertTrue(Arrays.equals(ARR_1, manager.convert("1")));
+		assertTrue(Arrays.equals(ARR_N3, manager.convert("-3")));
+		assertTrue(Arrays.equals(ARR_N3_4_5, manager.convert("-3,4,5")));
+		assertTrue(Arrays.equals(ARR_1P4, manager.convert("1.4")));
+		assertTrue(Arrays.equals(ARR_N3_4P1_5, manager.convert("-3,4.1,5")));
+	}
+
+	public void testGetIdentifier()
+	{
+		FormatManager<?> manager = factory.build("NUMBER", library);
+		assertEquals("ARRAY[NUMBER]", manager.getIdentifierType());
+		manager = factory.build("STRING", library);
+		assertEquals("ARRAY[STRING]", manager.getIdentifierType());
+	}
+
+	public void testManagedClass()
+	{
+		FormatManager<?> manager = factory.build("NUMBER", library);
+		assertEquals(new Number[]{}.getClass(), manager.getManagedClass());
+		manager = factory.build("STRING", library);
+		assertEquals(new String[]{}.getClass(), manager.getManagedClass());
+	}
+
+	public void testGetComponent()
+	{
+		FormatManager<?> manager = factory.build("NUMBER", library);
+		assertEquals(new NumberManager(), manager.getComponentManager());
+		manager = factory.build("STRING", library);
+		assertEquals(new StringManager(), manager.getComponentManager());
+	}
+}

--- a/PCGen-base/code/src/test/pcgen/base/formatmanager/SimpleFormatManagerLibraryTest.java
+++ b/PCGen-base/code/src/test/pcgen/base/formatmanager/SimpleFormatManagerLibraryTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2014 Tom Parker <thpr@users.sourceforge.net> This program is
+ * free software; you can redistribute it and/or modify it under the terms of
+ * the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 2.1 of the License, or (at your option) any later
+ * version.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+package pcgen.base.formatmanager;
+
+import java.util.Arrays;
+
+import junit.framework.TestCase;
+import pcgen.base.format.NumberManager;
+import pcgen.base.format.StringManager;
+import pcgen.base.util.FormatManager;
+
+public class SimpleFormatManagerLibraryTest extends TestCase
+{
+	private static final Number[] ARR_N3_4_5 = new Number[]{
+		Integer.valueOf(-3), Integer.valueOf(4), Integer.valueOf(5)};
+	private static final Number[] ARR_N3_4P1_5 = new Number[]{
+		Integer.valueOf(-3), Double.valueOf(4.1), Integer.valueOf(5)};
+	private static final Number[] ARR_1P4 = new Number[]{Double.valueOf(1.4)};
+	private static final Number[] ARR_N3 = new Number[]{Integer.valueOf(-3)};
+	private static final Number[] ARR_1 = new Number[]{Integer.valueOf(1)};
+
+	private SimpleFormatManagerLibrary library;
+
+	@Override
+	protected void setUp() throws Exception
+	{
+		super.setUp();
+		library = new SimpleFormatManagerLibrary();
+		FormatManagerLibraryUtilities.loadDefaultFormats(library);
+	}
+
+	public void testFailOnlyClose()
+	{
+		try
+		{
+			library.getFormatManager("NUMBER]");
+			fail("bad input value should fail");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//ok as well
+		}
+	}
+
+	public void testBadFormatFail()
+	{
+		try
+		{
+			library.getFormatManager("NIMBLER");
+			fail("null bad bracket value should fail");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//ok as well
+		}
+	}
+
+	public void testGetBad()
+	{
+		try
+		{
+			library.getFormatManager("ARRAY[NUMBER");
+			fail("null bad bracket value should fail");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//ok as well
+		}
+	}
+
+	public void testOneOnly()
+	{
+		try
+		{
+			library.addFormatManager(new NumberManager()
+			{
+				@Override
+				public String getIdentifierType()
+				{
+					//To force equality failure
+					return "STRING";
+				}
+			});
+			fail("can't add STRING twice with two different FormatManagers");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//ok as well
+		}
+		//This is okay (equality)
+		library.addFormatManager(new NumberManager());
+	}
+
+	public void testConvertFailBadSeparator()
+	{
+		try
+		{
+			library.getFormatManager("ARRAY[NIMBLER]");
+			fail("bad sub format should fail");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//ok as well
+		}
+	}
+
+	public void testConvert()
+	{
+		FormatManager<Number[]> manager =
+				(FormatManager<Number[]>) library
+					.getFormatManager("ARRAY[NUMBER]");
+		assertTrue(Arrays.equals(new Number[]{}, manager.convert(null)));
+		assertTrue(Arrays.equals(new Number[]{}, manager.convert("")));
+		assertTrue(Arrays.equals(ARR_1, manager.convert("1")));
+		assertTrue(Arrays.equals(ARR_N3, manager.convert("-3")));
+		assertTrue(Arrays.equals(ARR_N3_4_5, manager.convert("-3,4,5")));
+		assertTrue(Arrays.equals(ARR_1P4, manager.convert("1.4")));
+		assertTrue(Arrays.equals(ARR_N3_4P1_5, manager.convert("-3,4.1,5")));
+	}
+
+	public void testUnconvert()
+	{
+		FormatManager<Number[]> manager =
+				(FormatManager<Number[]>) library
+					.getFormatManager("ARRAY[NUMBER]");
+		assertEquals("1", manager.unconvert(ARR_1));
+		assertEquals("-3", manager.unconvert(ARR_N3));
+		assertEquals("-3,4,5", manager.unconvert(ARR_N3_4_5));
+		assertEquals("1.4", manager.unconvert(ARR_1P4));
+		assertEquals("-3,4.1,5", manager.unconvert(ARR_N3_4P1_5));
+		//Just to show it's not picky
+		assertEquals("1.4",
+			manager.unconvert(new Double[]{Double.valueOf(1.4)}));
+	}
+
+	public void testConvertIndirect()
+	{
+		FormatManager<Number[]> manager =
+				(FormatManager<Number[]>) library
+					.getFormatManager("ARRAY[NUMBER]");
+		assertTrue(Arrays.equals(new Number[]{}, manager.convertIndirect(null)
+			.get()));
+		assertTrue(Arrays.equals(new Number[]{}, manager.convertIndirect("")
+			.get()));
+		assertTrue(Arrays.equals(ARR_1, manager.convertIndirect("1").get()));
+		assertTrue(Arrays.equals(ARR_N3, manager.convertIndirect("-3").get()));
+		assertTrue(Arrays.equals(ARR_1P4, manager.convertIndirect("1.4").get()));
+		assertTrue(Arrays.equals(ARR_N3_4P1_5,
+			manager.convertIndirect("-3,4.1,5").get()));
+		assertTrue(Arrays.equals(ARR_N3_4_5, manager.convertIndirect("-3,4,5")
+			.get()));
+
+		assertEquals("", manager.convertIndirect(null).getUnconverted());
+		assertEquals("", manager.convertIndirect("").getUnconverted());
+		assertEquals("1", manager.convertIndirect("1").getUnconverted());
+		assertEquals("-3", manager.convertIndirect("-3").getUnconverted());
+		assertEquals("1.4", manager.convertIndirect("1.4").getUnconverted());
+		assertEquals("-3,4.1,5", manager.convertIndirect("-3,4.1,5")
+			.getUnconverted());
+		assertEquals("-3,4,5", manager.convertIndirect("-3,4,5")
+			.getUnconverted());
+	}
+
+	public void testGetIdentifier()
+	{
+		FormatManager<?> manager = library.getFormatManager("ARRAY[NUMBER]");
+		assertEquals("ARRAY[NUMBER]", manager.getIdentifierType());
+		manager = library.getFormatManager("ARRAY[STRING]");
+		assertEquals("ARRAY[STRING]", manager.getIdentifierType());
+		manager = library.getFormatManager("STRING");
+		assertEquals("STRING", manager.getIdentifierType());
+	}
+
+	public void testManagedClass()
+	{
+		FormatManager<?> manager = library.getFormatManager("ARRAY[NUMBER]");
+		assertEquals(new Number[]{}.getClass(), manager.getManagedClass());
+		manager = library.getFormatManager("ARRAY[STRING]");
+		assertEquals(new String[]{}.getClass(), manager.getManagedClass());
+		manager = library.getFormatManager("STRING");
+		assertEquals(String.class, manager.getManagedClass());
+	}
+
+	public void testGetComponent()
+	{
+		FormatManager<?> manager = library.getFormatManager("ARRAY[NUMBER]");
+		assertEquals(new NumberManager(), manager.getComponentManager());
+		manager = library.getFormatManager("ARRAY[STRING]");
+		assertEquals(new StringManager(), manager.getComponentManager());
+		manager = library.getFormatManager("STRING");
+		assertNull(manager.getComponentManager());
+	}
+}


### PR DESCRIPTION
Moves the rest of the infrastructure to support ARRAY[x] back into the base library, since the ArrayFormatManager already there was orphaned without the rest of the constructs, and this is not strictly linked to PCGen as a concept
