### PR TITLE
[CODE-3112] Donot publish javadoc and sources artifacts to runtime conf.

### DIFF
--- a/PCGen-base/build.gradle
+++ b/PCGen-base/build.gradle
@@ -115,12 +115,17 @@ publishing {
     publications {
         ivy(IvyPublication) {
             from components.java
+            configurations {
+                sources {}
+                javadoc {}
+            }
             artifact(sourceJar) {
                 type "sources"
-                conf "runtime"
+                conf "sources"
             }
             artifact(javadocJar) {
                 type "javadoc"
+                conf "javadoc"
             }
             descriptor.withXml {
                 asNode().info[0].appendNode('description', description)


### PR DESCRIPTION
The javadoc and sources are not needed at runtime.