### PR TITLE
Eliminate Order sorting from KeyMap

### DIFF
--- a/PCGen-base/code/src/java/pcgen/base/util/KeyMap.java
+++ b/PCGen-base/code/src/java/pcgen/base/util/KeyMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008 (C) Tom Parker <thpr@users.sourceforge.net>
+ * Copyright 2008-18 (C) Tom Parker <thpr@users.sourceforge.net>
  * 
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -20,7 +20,6 @@ package pcgen.base.util;
 import java.util.Collection;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -51,12 +50,6 @@ public class KeyMap<V>
 	private final Map<V, String> reverseMap;
 
 	/**
-	 * The underlying map used to store references from the Keys to the Values
-	 * based on input order to the KeyMap.
-	 */
-	private final List<V> inputOrder;
-
-	/**
 	 * Creates a new, empty DoubleKeyMap using HashMap as the underlying Map
 	 * class for both the primary and secondary underlying Map.
 	 */
@@ -64,7 +57,6 @@ public class KeyMap<V>
 	{
 		forwardMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 		reverseMap = new IdentityHashMap<>();
-		inputOrder = new IdentityList<>();
 	}
 
 	/**
@@ -74,7 +66,6 @@ public class KeyMap<V>
 	{
 		forwardMap.clear();
 		reverseMap.clear();
-		inputOrder.clear();
 	}
 
 	/**
@@ -178,8 +169,6 @@ public class KeyMap<V>
 			forwardMap.remove(oldKey);
 		}
 		reverseMap.remove(oldValue);
-		inputOrder.remove(oldValue);
-		inputOrder.add(value);
 		forwardMap.put(key, value);
 		reverseMap.put(value, key);
 		return oldValue;
@@ -191,7 +180,7 @@ public class KeyMap<V>
 	 * the given key, null is returned.
 	 * 
 	 * @param key
-	 *            The key used to identify which object to remove from thsi
+	 *            The key used to identify which object to remove from this
 	 *            KeyMap
 	 * @return Object The value previously mapped to the given keys
 	 */
@@ -202,7 +191,6 @@ public class KeyMap<V>
 			return null;
 		}
 		V value = forwardMap.remove(key);
-		inputOrder.remove(value);
 		reverseMap.remove(value);
 		return value;
 	}
@@ -234,28 +222,6 @@ public class KeyMap<V>
 	}
 
 	/**
-	 * Returns a Collection of the values for this KeyMap, ordered by the order
-	 * in which the Values were inserted into this KeyMap.
-	 * 
-	 * Note this is by order of the Values - if a Key is overwritten with a new
-	 * Value, then the new Value is placed at the end of this List, not at the
-	 * point where the old Value was present in the List.
-	 * 
-	 * Note: This Collection is both reference-semantic and value-semantic. The
-	 * ownership of the Collection is transferred to the calling Object;
-	 * therefore, changes to the returned Collection will NOT impact the KeyMap.
-	 * However, changes to the objects contained within the returned Collection
-	 * will change objects contained within this KeyMap.
-	 * 
-	 * @return A Collection of the values for this KeyMap, ordered by the order
-	 *         in which the Values were inserted into this KeyMap
-	 */
-	public List<V> insertOrderValues()
-	{
-		return new IdentityList<>(inputOrder);
-	}
-
-	/**
 	 * Returns a String representation of this KeyMap, primarily for purposes of
 	 * debugging. It is strongly advised that no dependency on this method be
 	 * created, as the return value may be changed without warning.
@@ -264,23 +230,5 @@ public class KeyMap<V>
 	public String toString()
 	{
 		return "KeyMap: " + forwardMap;
-	}
-
-	/**
-	 * Gets the Value of this KeyMap inserted as the nth element, as provided by
-	 * the given int.
-	 * 
-	 * Note this is by order of the Values - if a Key is overwritten with a new
-	 * Value, then the new Value is placed at the end of this List, not at the
-	 * point where the old Value was present in the List.
-	 * 
-	 * @param index
-	 *            The element number used to fetch a Value from this KeyMap.
-	 * @return the Value of this KeyMap inserted as the nth element, as provided
-	 *         by the given int
-	 */
-	public V getItemInOrder(int index)
-	{
-		return inputOrder.get(index);
 	}
 }

--- a/PCGen-base/code/src/java/pcgen/base/util/OneToOneMap.java
+++ b/PCGen-base/code/src/java/pcgen/base/util/OneToOneMap.java
@@ -180,7 +180,7 @@ public class OneToOneMap<K, V>
 	 * mapping for the given key, null is returned.
 	 * 
 	 * @param key
-	 *            The key used to identify which object to remove from thsi
+	 *            The key used to identify which object to remove from this
 	 *            OneToOneMap
 	 * @return Object The value previously mapped to the given keys
 	 */

--- a/PCGen-base/code/src/test/pcgen/base/util/KeyMapTest.java
+++ b/PCGen-base/code/src/test/pcgen/base/util/KeyMapTest.java
@@ -19,6 +19,7 @@ package pcgen.base.util;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Set;
 
 import junit.framework.TestCase;
@@ -233,50 +234,14 @@ public class KeyMapTest extends TestCase
 			//expected
 		}
 		assertEquals(3, s.size());
+		assertEquals(2, otom.keySortedValues().size());
 		otom.put(SC, D6);
+		s = otom.keySortedValues();
 		assertEquals(3, otom.keySet().size());
 		assertEquals(3, s.size());
-		//TODO Check actual ordering...
-	}
-
-	@Test
-	public void testInsertValues()
-	{
-		Collection<Double> s = otom.insertOrderValues();
-		assertNotNull(s);
-		assertEquals(0, s.size());
-		populate();
-		s = otom.insertOrderValues();
-		assertNotNull(s);
-		assertEquals(2, s.size());
-		//copy since we don't know what is returned is modifiable
-		Set<Double> full = new HashSet<>(s);
-		//make sure we didn't lose anything
-		assertEquals(2, full.size());
-		assertTrue(full.remove(D0));
-		assertTrue(full.remove(D5));
-		//check independence
-		try
-		{
-			s.add(D2);
-			assertEquals(2, otom.keySet().size());
-		}
-		catch (UnsupportedOperationException e)
-		{
-			//expected
-		}
-		assertEquals(3, s.size());
-		otom.put(SC, D6);
-		assertEquals(3, otom.keySet().size());
-		assertEquals(3, s.size());
-		//TODO Check actual ordering...
-	}
-
-	@Test
-	public void testGetItemInOrder()
-	{
-		populate();
-		assertEquals(D0, otom.getItemInOrder(0));
-		assertEquals(D5, otom.getItemInOrder(1));
+		Iterator<Double> iterator = s.iterator();
+		assertEquals(0.0, iterator.next());
+		assertEquals(5.0, iterator.next());
+		assertEquals(6.0, iterator.next());
 	}
 }


### PR DESCRIPTION
We can save some code now that there is no "by insert order" processing in PCGen... KeyMap can ignore insert order.
