### PR TITLE
Add items supporting Lambda functions

### DIFF
--- a/PCGen-base/code/src/java/pcgen/base/lambda/FailCollectingFilter.java
+++ b/PCGen-base/code/src/java/pcgen/base/lambda/FailCollectingFilter.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Thomas Parker, 2018.
+ * 
+ * This program is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 51 Franklin Street,
+ * Fifth Floor, Boston, MA 02110-1301, USA
+ */
+package pcgen.base.lambda;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * A Predicate that collects objects when they fail the test of a provided underlying
+ * Predicate.
+ * 
+ * @param <T>
+ *            The type of object processed by this FailCollectingFilter
+ */
+public class FailCollectingFilter<T> implements Predicate<T>
+{
+	/**
+	 * The underlying Predicate used to determine if items are kept in the stream (true)
+	 * or diverted to the collector (false).
+	 */
+	private final Predicate<T> predicate;
+
+	/**
+	 * The collector for situations where the Predicate returned false.
+	 */
+	private final Collection<T> collector;
+
+	/**
+	 * Constructs a new FailCollectingFilter for the given predicate and collection List.
+	 * 
+	 * This makes no attempt to validate that the given collector will accept new items.
+	 * That situation and all others related to the underlying behavior of the given
+	 * Collection are the responsibility of the object calling this constructor.
+	 * 
+	 * @param predicate
+	 *            The underlying Predicate used to determine if items are kept in the
+	 *            stream (true) or diverted to the collector (false)
+	 * @param collector
+	 *            The collector for situations where the Predicate returned false
+	 */
+	public FailCollectingFilter(Predicate<T> predicate, Collection<T> collector)
+	{
+		this.predicate = Objects.requireNonNull(predicate);
+		this.collector = Objects.requireNonNull(collector);
+	}
+
+	@Override
+	public boolean test(T t)
+	{
+		boolean passed = predicate.test(t);
+		if (!passed)
+		{
+			collector.add(t);
+		}
+		return passed;
+	}
+}

--- a/PCGen-base/code/src/java/pcgen/base/lambda/StreamUtilities.java
+++ b/PCGen-base/code/src/java/pcgen/base/lambda/StreamUtilities.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Thomas Parker, 2018.
+ * 
+ * This program is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 51 Franklin Street,
+ * Fifth Floor, Boston, MA 02110-1301, USA
+ * 
+ * Portions of this file are in the public domain. See:
+ * https://blog.codefx.org/java/stream-findfirst-findany-reduce/
+ */
+package pcgen.base.lambda;
+
+import java.util.function.BinaryOperator;
+import java.util.function.Supplier;
+
+/**
+ * A Utility class that supports methods to be used with Streams.
+ */
+public class StreamUtilities
+{
+	/**
+	 * This supports a smarter replacement for findFirst() that will guarantee only one
+	 * matching element.
+	 * 
+	 * This is designed to be used after a filter, and will reduce a Stream to a single
+	 * matching element, but throwing an exception if more than one element is present.
+	 * 
+	 * @param <T>
+	 *            The type of object in the Stream
+	 * @return A BinaryOperator which will throw an exception if more than one element is
+	 *         present in the Stream
+	 */
+	public static <T> BinaryOperator<T> toOnlyElement()
+	{
+		return toOnlyElementThrowing(IllegalArgumentException::new);
+	}
+
+	/**
+	 * This supports a smarter replacement for findFirst() that will guarantee only one
+	 * matching element.
+	 * 
+	 * This is designed to be used after a filter, and will reduce a Stream to a single
+	 * matching element, but throwing an exception if more than one element is present.
+	 * 
+	 * @param exception
+	 *            A supplier of an exception to be thrown if more than one object is found
+	 *            in the Stream
+	 * @param <T>
+	 *            The type of object in the Stream
+	 * @return A BinaryOperator which will throw an exception if more than one element is
+	 *         present in the Stream
+	 */
+	public static <T, E extends RuntimeException> BinaryOperator<T> toOnlyElementThrowing(
+		Supplier<E> exception)
+	{
+		return (element, otherElement) -> {
+			throw exception.get();
+		};
+	}
+}

--- a/PCGen-base/code/src/test/pcgen/base/lambda/FailCollectingFilterTest.java
+++ b/PCGen-base/code/src/test/pcgen/base/lambda/FailCollectingFilterTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Thomas Parker, 2018.
+ * 
+ * This program is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 51 Franklin Street,
+ * Fifth Floor, Boston, MA 02110-1301, USA
+ */
+package pcgen.base.lambda;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import junit.framework.TestCase;
+import pcgen.base.lambda.testsupport.SupportingBuilder;
+
+public class FailCollectingFilterTest extends TestCase
+{
+
+	public void testCollectionList()
+	{
+		List<Integer> list = SupportingBuilder.buildIntegerList();
+		List<Integer> failures = new ArrayList<>();
+		Optional<Integer> s =
+				list.stream().filter(new FailCollectingFilter<>(t -> t == 2, failures))
+					.reduce(StreamUtilities.toOnlyElement());
+		assertTrue(s.isPresent());
+		assertEquals(Integer.valueOf(2), s.get());
+		assertEquals(3, failures.size());
+		assertTrue(failures.remove(Integer.valueOf(1)));
+		assertTrue(failures.remove(Integer.valueOf(3)));
+		assertTrue(failures.remove(Integer.valueOf(3)));
+	}
+
+	public void testCollectionListNoSuccess()
+	{
+		List<Integer> list = SupportingBuilder.buildIntegerList();
+		List<Integer> failures = new ArrayList<>();
+		Optional<Integer> s =
+				list.stream().filter(new FailCollectingFilter<>(t -> t == 42, failures))
+					.reduce(StreamUtilities.toOnlyElement());
+		assertFalse(s.isPresent());
+		assertEquals(4, failures.size());
+		assertTrue(failures.remove(Integer.valueOf(1)));
+		assertTrue(failures.remove(Integer.valueOf(2)));
+		assertTrue(failures.remove(Integer.valueOf(3)));
+		assertTrue(failures.remove(Integer.valueOf(3)));
+	}
+}

--- a/PCGen-base/code/src/test/pcgen/base/lambda/StreamUtilitiesTest.java
+++ b/PCGen-base/code/src/test/pcgen/base/lambda/StreamUtilitiesTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Thomas Parker, 2018.
+ * 
+ * This program is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 51 Franklin Street,
+ * Fifth Floor, Boston, MA 02110-1301, USA
+ */
+package pcgen.base.lambda;
+
+import java.util.List;
+import java.util.Optional;
+
+import junit.framework.TestCase;
+import pcgen.base.lambda.testsupport.SupportingBuilder;
+
+public class StreamUtilitiesTest extends TestCase
+{
+
+	public void testToOnlyElementSuccess()
+	{
+		List<Integer> list = SupportingBuilder.buildIntegerList();
+		Optional<Integer> s =
+				list.stream().filter(t -> t == 2).reduce(StreamUtilities.toOnlyElement());
+		assertTrue(s.isPresent());
+		assertEquals(Integer.valueOf(2), s.get());
+	}
+
+	public void testToOnlyElementMissed()
+	{
+		List<Integer> list = SupportingBuilder.buildIntegerList();
+		Optional<Integer> s = list.stream().filter(t -> t == 42)
+			.reduce(StreamUtilities.toOnlyElement());
+		assertFalse(s.isPresent());
+	}
+
+	public void testToOnlyElementFailure()
+	{
+		List<Integer> list = SupportingBuilder.buildIntegerList();
+		try
+		{
+			list.stream().filter(t -> t == 3).reduce(StreamUtilities.toOnlyElement());
+			fail("Expected reduce to fail since there are two elements of value 3");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//Expected
+		}
+	}
+
+}

--- a/PCGen-base/code/src/test/pcgen/base/lambda/testsupport/SupportingBuilder.java
+++ b/PCGen-base/code/src/test/pcgen/base/lambda/testsupport/SupportingBuilder.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Thomas Parker, 2018.
+ * 
+ * This program is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 51 Franklin Street,
+ * Fifth Floor, Boston, MA 02110-1301, USA
+ */
+package pcgen.base.lambda.testsupport;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SupportingBuilder
+{
+	public static List<Integer> buildIntegerList()
+	{
+		List<Integer> list = new ArrayList<>();
+		list.add(1);
+		list.add(2);
+		list.add(3);
+		list.add(3);
+		return list;
+	}
+}


### PR DESCRIPTION
Okay, this one is a bit fun.

This is a series of helper functions in the Lambda domain.

Note: This PR should be reviewed for design purpose in addition to the actual code content.  I specifically want a review from folks more familiar with this than I am.... making sure there is not a better way to do this with streams.

Martijn had suggested in PCGen PR # 3797, see   https://github.com/PCGen/pcgen/pull/3797 whether things like the AbilityLoader could be done with streams.  I think things of that behavior are hard to do with the built-in capabilities.  This base library addition is meant to allow that upgrade.

The intent here would be to use code like:
```
List<String> otherTokens = new ArrayList<String>();
Optional<String> categoryToken = Arrays
	.stream(tokens.get().split(SystemLoader.TAB_DELIM))
	.filter(s -> s.length() > 0)
	.filter(
		new FailCollectingFilter<>(s -> s.startsWith("CATEGORY:"), otherTokens))
	.reduce((a, b) -> report(a, b,
		"Ignoring CATEGORY which appeared twice on original line of an Ability ("
			+ anAbility.getDisplayName() + ") in line: " + lstLine,
		context));
```

Specifically this consumes the CATEGORY: token into categoryToken, forcing there to be only one (or a report is provided to the error log).  The other tokens are then provided into otherTokens.

```
    public <T> T report(T a, T b, String s, LoadContext context)
    {
    	Logging.errorPrint(s, context);
    	return a;
    }
```

Today we are doing Logging.errorPrint - in the future, we may choose to go back to exceptions rather than doing it by ParseResult and error logs, so that is why the other functions are available here - eventually the report method could go away, and the reduce would call toOnlyElementThrowing...