### PR TITLE
Proxy library items

### DIFF
--- a/PCGen-base/code/src/java/pcgen/base/proxy/DeferredMethodController.java
+++ b/PCGen-base/code/src/java/pcgen/base/proxy/DeferredMethodController.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.proxy;
+
+import java.util.Objects;
+
+/**
+ * A DeferredMethodController is an object used to push actions from a Staging into a
+ * target object of a given type.
+ * 
+ * @param <T>
+ *            The Format of the relevant Interface that is being used by the CommitTask.
+ */
+public class DeferredMethodController<T>
+{
+
+	/**
+	 * The Staging object that contains the information to be pushed into the targetObject
+	 * when process() is called.
+	 */
+	private final Staging<T> staging;
+
+	/**
+	 * The target Object to be modified when process() is called.
+	 */
+	private final T targetObject;
+
+	/**
+	 * Constructs a new DeferredMethodController from the given Staging and target Object.
+	 * 
+	 * @param staging
+	 *            The Staging object that contains the information to be pushed into the
+	 *            targetObject when process() is called
+	 * @param targetObject
+	 *            The target Object to be modified when process() is called
+	 */
+	public DeferredMethodController(Staging<T> staging, T targetObject)
+	{
+		this.staging = Objects.requireNonNull(staging);
+		this.targetObject = Objects.requireNonNull(targetObject);
+		Class<T> cl = staging.getInterface();
+		if (!cl.isAssignableFrom(targetObject.getClass()))
+		{
+			throw new IllegalArgumentException(
+				"Target must be compatible with the given Staging");
+		}
+	}
+
+	/**
+	 * Performs the actual commitment of information from the Staging to the target
+	 * Object.
+	 */
+	public void run()
+	{
+		staging.applyTo(targetObject);
+	}
+}

--- a/PCGen-base/code/src/java/pcgen/base/proxy/ItemProcessor.java
+++ b/PCGen-base/code/src/java/pcgen/base/proxy/ItemProcessor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.proxy;
+
+import java.lang.reflect.Method;
+
+/**
+ * An ItemProcessor is a PropertyProcessor that handles Item-based properties. These are
+ * properties that use "setX" to add an item to the object and "getX" to retrieve the
+ * object.
+ */
+public class ItemProcessor implements PropertyProcessor
+{
+
+	@Override
+	public boolean isProcessedMethod(Method method)
+	{
+		return method.getName().regionMatches(true, 0, "set", 0, 3)
+			&& (method.getParameterTypes().length == 1)
+			&& (method.getReturnType() == void.class);
+	}
+
+	@Override
+	public String getPropertyName(String methodName)
+	{
+		return methodName.substring(3);
+	}
+
+	@Override
+	public Method claimMethod(Method setMethod, Method[] possibleReadMethods)
+	{
+		String propertyName = getPropertyName(setMethod.getName());
+		Method getMethod = PropertyProcessor.retrieveMethod("get" + propertyName,
+			possibleReadMethods);
+		if (getMethod.getParameterTypes().length != 0)
+		{
+			throw new IllegalArgumentException("Did not expect GET Method: "
+				+ getMethod.getName() + " to have arguments");
+		}
+		Class<?>[] setParams = setMethod.getParameterTypes();
+		if (!setParams[0].equals(getMethod.getReturnType()))
+		{
+			throw new IllegalArgumentException("SET Method: " + setMethod.getName()
+				+ " set format: " + setParams[0].getCanonicalName() + " but GET Method: "
+				+ getMethod.getName() + " returned a "
+				+ getMethod.getReturnType().getCanonicalName());
+		}
+		return getMethod;
+	}
+
+	@Override
+	public ReadableHandler getInvocationHandler(String methodName, Object[] args)
+	{
+		return new ReadItemProperty(methodName.substring(3));
+	}
+
+}

--- a/PCGen-base/code/src/java/pcgen/base/proxy/ListProcessor.java
+++ b/PCGen-base/code/src/java/pcgen/base/proxy/ListProcessor.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.proxy;
+
+import java.lang.reflect.Method;
+
+/**
+ * A ListProcessor is a PropertyProcessor that handles List-based properties. These are
+ * properties that use "addX" to add items to the list and "getXArray" to retrieve the
+ * list.
+ */
+public class ListProcessor implements PropertyProcessor
+{
+
+	@Override
+	public boolean isProcessedMethod(Method method)
+	{
+		return method.getName().regionMatches(true, 0, "add", 0, 3)
+			&& (method.getParameterTypes().length == 1)
+			&& (method.getReturnType() == void.class);
+	}
+
+	@Override
+	public String getPropertyName(String methodName)
+	{
+		return methodName.substring(3);
+	}
+
+	@Override
+	public Method claimMethod(Method addMethod, Method[] possibleReadMethods)
+	{
+		String propertyName = getPropertyName(addMethod.getName());
+		Method getMethod = PropertyProcessor
+			.retrieveMethod("get" + propertyName + "Array", possibleReadMethods);
+		if (getMethod.getParameterTypes().length != 0)
+		{
+			throw new IllegalArgumentException("Did not expect GET Method: "
+				+ getMethod.getName() + " to have arguments");
+		}
+		Class<?>[] setParams = addMethod.getParameterTypes();
+		Class<?> returnType = getMethod.getReturnType();
+		if (!returnType.isArray())
+		{
+			throw new IllegalArgumentException("ADD Method: " + addMethod.getName()
+				+ " set format: " + setParams[0].getCanonicalName() + " but GET Method: "
+				+ getMethod.getName() + " did not return an array: "
+				+ getMethod.getReturnType().getCanonicalName());
+		}
+		if (!setParams[0].equals(returnType.getComponentType()))
+		{
+			throw new IllegalArgumentException("ADD Method: " + addMethod.getName()
+				+ " set format: " + setParams[0].getCanonicalName() + " but GET Method: "
+				+ getMethod.getName() + " returned a "
+				+ getMethod.getReturnType().getCanonicalName());
+		}
+		return getMethod;
+	}
+
+	@Override
+	public ReadableHandler getInvocationHandler(String methodName, Object[] args)
+	{
+		return new ReadListProperty(methodName);
+	}
+
+}

--- a/PCGen-base/code/src/java/pcgen/base/proxy/MapProcessor.java
+++ b/PCGen-base/code/src/java/pcgen/base/proxy/MapProcessor.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.proxy;
+
+import java.lang.reflect.Method;
+
+/**
+ * A MapProcessor is a PropertyProcessor that handles Map-based properties. These are
+ * properties that use "put" or "putX" to set items in the map and "get" or "getX" to
+ * retrieve items.
+ * 
+ * Note that it is expected that the put* methods take two parameters (key and value) and
+ * get* methods take a single parameter, which is the key to the map.
+ */
+public class MapProcessor implements PropertyProcessor
+{
+
+	@Override
+	public boolean isProcessedMethod(Method method)
+	{
+		return method.getName().regionMatches(true, 0, "put", 0, 3)
+			&& (method.getParameterTypes().length == 2)
+			&& (method.getReturnType() == void.class);
+
+	}
+
+	@Override
+	public String getPropertyName(String methodName)
+	{
+		return methodName.equalsIgnoreCase("put") ? "" : methodName.substring(3);
+	}
+
+	@Override
+	public Method claimMethod(Method putMethod, Method[] possibleReadMethods)
+	{
+		String name = putMethod.getName();
+		String propertyName = getPropertyName(name);
+		Method getMethod = PropertyProcessor.retrieveMethod("get" + propertyName,
+			possibleReadMethods);
+		Class<?>[] getParams = getMethod.getParameterTypes();
+		if (getParams.length != 1)
+		{
+			throw new IllegalArgumentException(
+				"Expected " + getMethod.getName() + " to have one argument");
+		}
+		Class<?>[] setParams = putMethod.getParameterTypes();
+		Class<?> getParameter = getParams[0];
+		if (!getParameter.equals(setParams[0]))
+		{
+			throw new IllegalArgumentException(
+				putMethod.getName() + " set lookup format: "
+					+ setParams[0].getCanonicalName() + " but " + getMethod.getName()
+					+ " fetched via a " + getParameter.getCanonicalName());
+		}
+		if (!setParams[1].equals(getMethod.getReturnType()))
+		{
+			throw new IllegalArgumentException(putMethod.getName() + " added format: "
+				+ setParams[1].getCanonicalName() + " but " + getMethod.getName()
+				+ " returned a " + getMethod.getReturnType().getCanonicalName());
+		}
+		return getMethod;
+	}
+
+	@Override
+	public ReadableHandler getInvocationHandler(String methodName, Object[] args)
+	{
+		String propertyName =
+				methodName.equalsIgnoreCase("get") ? "" : methodName.substring(3);
+		return new ReadMapProperty(propertyName, args[0]);
+	}
+
+}

--- a/PCGen-base/code/src/java/pcgen/base/proxy/PropertyProcessor.java
+++ b/PCGen-base/code/src/java/pcgen/base/proxy/PropertyProcessor.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2018 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.proxy;
+
+import java.lang.reflect.Method;
+
+/**
+ * A PropertyProcessor is capable of evaluating read and write methods and determining if
+ * they meet a specific behavior that would have those methods recognized as a property of
+ * an object that implements one or both of those interfaces.
+ * 
+ * These objects effectively perform analysis similar to that which might be performed in
+ * evaluating if an object is a JavaBean, although PropertyProcessor objects may allow
+ * significantly more flexibility (and an object need not have both a getter and setter
+ * for a PropertyProcessor to evaluate or work with that object).
+ * 
+ * Note: This interface assumes that a write method (e.g. setX) will only claim one read
+ * method. This may or may not be true, and in general, introspection here is challenging,
+ * in that this can't be very intelligent about what it claims. On the other hand, this
+ * current design is stateless, which is a help in reducing object count.
+ */
+public interface PropertyProcessor
+{
+	/**
+	 * Returns true if the given Method is a method processed by this PropertyProcessor.
+	 * This method should be on a WRITEABLE interface, meaning it is a "set", "put",
+	 * "add", etc. that is intended to write to the object.
+	 * 
+	 * Note: This method must perform sufficient actions such that claimMethod will not
+	 * reject the "writeable" method provided here.
+	 * 
+	 * @param writeMethod
+	 *            The Method to be evaluated to determine if it is processed by this
+	 *            PropertyProcessor.
+	 * @return true if the given Method is a method processed by this PropertyProcessor;
+	 *         false otherwise
+	 */
+	public boolean isProcessedMethod(Method writeMethod);
+
+	/**
+	 * Returns the property name given a write method name.
+	 * 
+	 * @param methodName
+	 *            The write method name to be converted to the property name
+	 * @return The property name as derived from the given write method name
+	 */
+	public String getPropertyName(String writeMethodName);
+
+	/**
+	 * Returns the Method "claimed" as being the "read" Method associated with the given
+	 * "write" Method. This method will be from the given array of possible "read"
+	 * Methods.
+	 * 
+	 * In effect, this determines the matching pair of "read"/"write" Methods for a given
+	 * property by using the given "write" Method to establish which property is being
+	 * evaluated.
+	 * 
+	 * Note: This method may reserve the right to throw exceptions if some behavior does
+	 * not properly match between the "read"/"write" Methods for a given property.
+	 * Specifically, if the read and write return different Classes, then the
+	 * PropertyProcessor can refuse to proceed.
+	 * 
+	 * @param writeMethod
+	 *            The "write" Method used to establish the property being evaluated (and
+	 *            to validate the "read" method is compatible)
+	 * @param possibleReadMethods
+	 *            The possible "read" Methods to be checked to determine which one is the
+	 *            Method associated with the given "write" Method
+	 * @return A Method from the array of possible "read" Methods that is "claimed" as
+	 *         being the "read" Method associated with the given "write" Method
+	 */
+	public Method claimMethod(Method writeMethod, Method[] possibleReadMethods);
+
+	/**
+	 * Returns a ReadableHandler for the given method name and arguments.
+	 * 
+	 * @param methodName
+	 *            The Method name for which a ReadableHandler should be returned
+	 * @param args
+	 *            The arguments that may be needed to construct the appropriate
+	 *            ReadableHandler
+	 * @return A ReadableHandler for the given method name and arguments
+	 */
+	public ReadableHandler getInvocationHandler(String methodName, Object[] args);
+
+	/**
+	 * Returns a Method from the given Array of Method objects which has the given Method
+	 * name. An IllegalArgumentException is returned if none of the Methods in the given
+	 * Array has the given name.
+	 * 
+	 * @param methodName
+	 *            The Method name to be checked against the given possible Methods
+	 * @param possibleMethods
+	 *            The Array of possible Methods to be checked
+	 * @return A Method from the given Array of Method objects which has the given Method
+	 *         name
+	 * @throws IllegalArgumentException
+	 *             if none of the Methods in the given Array has the given name
+	 */
+	public static Method retrieveMethod(String methodName, Method[] possibleMethods)
+	{
+		for (Method m : possibleMethods)
+		{
+			if (m.getName().equalsIgnoreCase(methodName))
+			{
+				return m;
+			}
+		}
+		throw new IllegalArgumentException(
+			"Expected Method: " + methodName + " to exist");
+	}
+
+}

--- a/PCGen-base/code/src/java/pcgen/base/proxy/ReadItemProperty.java
+++ b/PCGen-base/code/src/java/pcgen/base/proxy/ReadItemProperty.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.proxy;
+
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+/**
+ * A ReadItemProperty is a ReadableHandler that handles Item-based Properties.
+ */
+public class ReadItemProperty implements ReadableHandler
+{
+	/**
+	 * The set method name for the Property to be processed by this ReadItemProperty.
+	 */
+	private final String setMethodName;
+
+	/**
+	 * The resulting value of the Property after this ReadItemProperty is appropriately
+	 * invoked.
+	 */
+	private Object value;
+
+	/**
+	 * Constructs a new ReadItemProperty for the given Property name.
+	 * 
+	 * @param propertyName
+	 *            The Property name that this ReadItemProperty will process
+	 */
+	public ReadItemProperty(String propertyName)
+	{
+		this.setMethodName = "set" + Objects.requireNonNull(propertyName);
+	}
+
+	@Override
+	public Object invoke(Object proxy, Method method, Object[] args) throws Throwable
+	{
+		if (!void.class.equals(method.getReturnType()))
+		{
+			throw new IllegalArgumentException("Expected invoked set method ("
+					+ setMethodName + ") to have a void return type");
+		}
+		if (method.getName().equalsIgnoreCase(setMethodName))
+		{
+			value = args[0];
+		}
+		return null;
+	}
+
+	@Override
+	public Object getResult()
+	{
+		return value;
+	}
+}

--- a/PCGen-base/code/src/java/pcgen/base/proxy/ReadListProperty.java
+++ b/PCGen-base/code/src/java/pcgen/base/proxy/ReadListProperty.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.proxy;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A ReadItemProperty is a ReadableHandler that handles List-based Properties.
+ */
+public class ReadListProperty implements ReadableHandler
+{
+	/**
+	 * The add method name for the Property to be processed by this ReadListProperty.
+	 */
+	private final String addMethodName;
+
+	/**
+	 * The resulting value of the Property after this ReadListProperty is appropriately
+	 * invoked.
+	 */
+	private List<Object> value = new ArrayList<>();
+
+	/**
+	 * Constructs a new ReadListProperty for the given Property name.
+	 * 
+	 * @param propertyName
+	 *            The Property name that this ReadListProperty will process
+	 */
+	public ReadListProperty(String propertyName)
+	{
+		this.addMethodName = "add" + Objects.requireNonNull(propertyName);
+	}
+
+	@Override
+	public Object invoke(Object proxy, Method method, Object[] args) throws Throwable
+	{
+		if (!void.class.equals(method.getReturnType()))
+		{
+			throw new IllegalArgumentException("Expected invoked set method ("
+					+ addMethodName + ") to have a void return type");
+		}
+		if (method.getName().equalsIgnoreCase(addMethodName))
+		{
+			value.add(args[0]);
+		}
+		return null;
+	}
+
+	@Override
+	public Object getResult()
+	{
+		return value;
+	}
+}

--- a/PCGen-base/code/src/java/pcgen/base/proxy/ReadMapProperty.java
+++ b/PCGen-base/code/src/java/pcgen/base/proxy/ReadMapProperty.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.proxy;
+
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+/**
+ * A ReadMapProperty is a ReadableHandler that handles Map-based Properties.
+ */
+public class ReadMapProperty implements ReadableHandler
+{
+	/**
+	 * The set method name for the Property to be processed by this ReadMapProperty.
+	 */
+	private final String putMethodName;
+
+	/**
+	 * The key for the portion of the Property to be processed by this ReadMapProperty.
+	 */
+	private final Object key;
+
+	/**
+	 * The resulting value of the Property after this ReadMapProperty is appropriately
+	 * invoked.
+	 */
+	private Object value;
+
+	/**
+	 * Constructs a new ReadMapProperty for the given Property name and map key.
+	 * 
+	 * @param propertyName
+	 *            The Property name that this ReadMapProperty will process
+	 * @param key
+	 *            The key for the portion of the Property to be processed by this
+	 *            ReadMapProperty
+	 */
+	public ReadMapProperty(String propertyName, Object key)
+	{
+		this.putMethodName = "put" + Objects.requireNonNull(propertyName);
+		this.key = Objects.requireNonNull(key);
+	}
+
+	@Override
+	public Object invoke(Object proxy, Method method, Object[] args) throws Throwable
+	{
+		if (!void.class.equals(method.getReturnType()))
+		{
+			throw new IllegalArgumentException("Expected invoked set method ("
+					+ putMethodName + ") to have a void return type");
+		}
+		if (method.getName().equalsIgnoreCase(putMethodName) && key.equals(args[0]))
+		{
+			value = args[1];
+		}
+		return null;
+	}
+
+	@Override
+	public Object getResult()
+	{
+		return value;
+	}
+}

--- a/PCGen-base/code/src/java/pcgen/base/proxy/ReadableHandler.java
+++ b/PCGen-base/code/src/java/pcgen/base/proxy/ReadableHandler.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.proxy;
+
+import java.lang.reflect.InvocationHandler;
+
+/**
+ * A ReadableHandler is an InvocationHandler designed to return a value from a
+ * SplitContextFactory, by serving as the InvocationHandler for the write interface of the
+ * property to be read.
+ */
+public interface ReadableHandler extends InvocationHandler
+{
+	/**
+	 * Returns the result of the property for which this is serving as the
+	 * InvocationHandler on the write interface of the property.
+	 * 
+	 * @return The result of the property for which this is serving as the
+	 *         InvocationHandler on the write interface of the property
+	 */
+	public Object getResult();
+}

--- a/PCGen-base/code/src/java/pcgen/base/proxy/Staging.java
+++ b/PCGen-base/code/src/java/pcgen/base/proxy/Staging.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.proxy;
+
+/**
+ * A Staging is an object which has certain staged information which can be applied to an
+ * object of the Class (by design, an interface) processed by this Staging.
+ * 
+ * @param <T>
+ *            The Class of the (write) interface that this Staging will call on the target
+ *            object when applyTo is called.
+ */
+public interface Staging<T>
+{
+	/**
+	 * Applies the contents of this Staging to the given object (which must implement the
+	 * reference interface of this Staging). The contents represents the method calls that
+	 * were captured by this Staging.
+	 * 
+	 * @param target
+	 *            The target object (which must implement the write interface of this
+	 *            Staging), on which the method calls captured by this Staging will be
+	 *            repeated
+	 */
+	public void applyTo(T target);
+
+	/**
+	 * Returns the Class of the interface of this Staging.
+	 * 
+	 * @return The Class of the interface of this Staging
+	 */
+	public Class<T> getInterface();
+}

--- a/PCGen-base/code/src/java/pcgen/base/proxy/StagingInfo.java
+++ b/PCGen-base/code/src/java/pcgen/base/proxy/StagingInfo.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.proxy;
+
+import java.util.Objects;
+
+/**
+ * A StagingInfo is a container for the read and write Proxy objects and the related
+ * Staging object for information to be staged for later use.
+ * 
+ * @param <R>
+ *            The Interface (Class) of Object which is the read interface supported by
+ *            this StagingInfo.
+ * @param <W>
+ *            The Interface (Class) of Object which is the write interface supported by
+ *            this StagingInfo.
+ */
+public class StagingInfo<R, W>
+{
+
+	/**
+	 * The Proxy for the read interface supported by this StagingInfo.
+	 */
+	private final R readProxy;
+
+	/**
+	 * The Proxy for the write interface supported by this StagingInfo.
+	 */
+	private final W writeProxy;
+
+	/**
+	 * The Staging object supported by this StagingInfo.
+	 */
+	private final Staging<W> stagingObject;
+
+	/**
+	 * Constructs a new StagingInfo with the given read Proxy, write Proxy, and Staging
+	 * object.
+	 * 
+	 * @param readProxy
+	 *            The Proxy for the read interface supported by this StagingInfo
+	 * @param writeProxy
+	 *            The Proxy for the write interface supported by this StagingInfo
+	 * @param stagingObject
+	 *            The Staging object supported by this StagingInfo
+	 */
+	public StagingInfo(R readProxy, W writeProxy, Staging<W> stagingObject)
+	{
+		this.readProxy = Objects.requireNonNull(readProxy);
+		this.writeProxy = Objects.requireNonNull(writeProxy);
+		this.stagingObject = Objects.requireNonNull(stagingObject);
+	}
+
+	/**
+	 * Returns the Proxy for the read interface supported by this StagingInfo.
+	 * 
+	 * @return The Proxy for the read interface supported by this StagingInfo
+	 */
+	public R getReadProxy()
+	{
+		return readProxy;
+	}
+
+	/**
+	 * Returns the Proxy for the write interface supported by this StagingInfo.
+	 * 
+	 * @return The Proxy for the write interface supported by this StagingInfo
+	 */
+	public W getWriteProxy()
+	{
+		return writeProxy;
+	}
+
+	/**
+	 * Returns the Staging object supported by this StagingInfo.
+	 * 
+	 * @return The Staging object supported by this StagingInfo
+	 */
+	public Staging<W> getStagingObject()
+	{
+		return stagingObject;
+	}
+}

--- a/PCGen-base/code/src/java/pcgen/base/proxy/StagingInfoFactory.java
+++ b/PCGen-base/code/src/java/pcgen/base/proxy/StagingInfoFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.proxy;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A StagingInfoFactory is a factory for StagingInfo objects. This class holds the master
+ * list of PropertyProcessor objects which will be available to StagingProxy objects built
+ * by this StagingInfoFactory.
+ */
+public class StagingInfoFactory
+{
+	/**
+	 * The List of PropertyProcessor objects to be provided to the StagingProxy objects
+	 * constructed by this StagingInfoFactory.
+	 */
+	private List<PropertyProcessor> processors = new ArrayList<>();
+
+	/**
+	 * Adds a new PropertyProcessor to the List of PropertyProcessor objects in this
+	 * StagingInfoFactory.
+	 * 
+	 * @param processor
+	 *            The PropertyProcessor to be added to the List of PropertyProcessor
+	 *            objects in this StagingInfoFactory
+	 */
+	public void addProcessor(PropertyProcessor processor)
+	{
+		processors.add(processor);
+	}
+
+	/**
+	 * Constructs a new StagingProxy for the given read and write interfaces. This returns
+	 * a StagingInfo that contains the necessary Proxy objects for the interfaces as well
+	 * as a Staging for the write interface.
+	 * 
+	 * @param readInterface
+	 *            The read interface to be used to construct the returned Staging
+	 * @param writeInterface
+	 *            The write interface to be used to construct both the returned Proxy
+	 *            object and the returned Staging
+	 * @return A StagingInfo containing the necessary Proxy objects for the interfaces as
+	 *         well as a Staging for the write interface
+	 */
+	public <R, W> StagingInfo<R, W> produceStaging(Class<R> readInterface,
+		Class<W> writeInterface)
+	{
+		StagingProxy<R, W> factory =
+				new StagingProxy<>(processors, readInterface, writeInterface);
+		@SuppressWarnings("unchecked")
+		W writeProxy = (W) java.lang.reflect.Proxy.newProxyInstance(
+			writeInterface.getClassLoader(), new Class[]{writeInterface}, factory);
+		@SuppressWarnings("unchecked")
+		R readProxy = (R) java.lang.reflect.Proxy.newProxyInstance(
+			readInterface.getClassLoader(), new Class[]{readInterface}, factory);
+		return new StagingInfo<>(readProxy, writeProxy, factory);
+	}
+
+}

--- a/PCGen-base/code/src/java/pcgen/base/proxy/StagingProxy.java
+++ b/PCGen-base/code/src/java/pcgen/base/proxy/StagingProxy.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2018 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.proxy;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import pcgen.base.util.CaseInsensitiveMap;
+import pcgen.base.util.Tuple;
+
+/**
+ * A StagingProxy is a Staging object. The InvocationHandler portion is provided methods
+ * and arguments that are calls to the interface which is processed by this StagingProxy.
+ * 
+ * When this StagingProxy is applied to an object, the calls previously recorded by the
+ * InvocationHandler are then repeated on the provided target.
+ * 
+ * In general, this is convenient for staging the initial processing (to ensure something
+ * is valid) from the final application of the result of the processing.
+ * 
+ * Note that it is assumed that ALL methods on the "write" interface return void
+ * (Technically it is slightly more lenient: write methods must be capable of being
+ * declared a success if they return a null value, but this extra leniency is likely to be
+ * useful only in rare cases). This is a primary requirement for the StagingProxy to be
+ * able to stage information (StagingProxy cannot guess at what an appropriate answer
+ * would be to an arbitrary write if feedback was required).
+ * 
+ * @param <R>
+ *            The Interface (Class) of Object which is the read interface processed by
+ *            this StagingProxy.
+ * @param <W>
+ *            The Interface (Class) of Object which is the write interface processed by
+ *            this StagingProxy.
+ */
+class StagingProxy<R, W> implements InvocationHandler, Staging<W>
+{
+	/**
+	 * The list of PropertyProcessor objects that this StagingProxy will consider when
+	 * interpreting the given interfaces.
+	 */
+	private List<PropertyProcessor> processors;
+
+	/**
+	 * This is the read interface (interface with "get" methods) served by this
+	 * StagingProxy.
+	 */
+	private final Class<R> readInterface;
+
+	/**
+	 * This is the write interface (interface with "set"/"add"/"put" methods) served by
+	 * this StagingProxy.
+	 */
+	private final Class<W> writeInterface;
+
+	/**
+	 * This is the map from the (read) method name to the processors for the methods on
+	 * the read interface of this StagingProxy.
+	 */
+	private Map<String, PropertyProcessor> getProcessors = new HashMap<>();
+
+	/**
+	 * This is the set of "set"/"add"/"put" methods served by this StagingProxy.
+	 */
+	private Set<String> setMethods = new HashSet<>();
+
+	/**
+	 * This is the List of method calls to the write interface that this StagingProxy has
+	 * captured (while serving as an InvocationHandler).
+	 */
+	private List<Tuple<Method, Object[]>> stagedMethodCalls;
+
+	/**
+	 * Constructs a new StagingProxy for the given List of PropertyProcessor objects and
+	 * the given read and write interfaces.
+	 * 
+	 * @param processorList
+	 *            The list of PropertyProcessor objects that this StagingProxy will
+	 *            consider when interpreting the given interfaces
+	 * @param readInterface
+	 *            The read interface (interface with "get" methods) served by this
+	 *            StagingProxy.
+	 * @param writeInterface
+	 *            The write interface (interface with "set"/"add"/"put" methods) served by
+	 *            this StagingProxy.
+	 */
+	StagingProxy(List<PropertyProcessor> processorList, Class<R> readInterface,
+		Class<W> writeInterface)
+	{
+		if (!readInterface.isInterface())
+		{
+			throw new IllegalArgumentException(
+				"ContextFactory must be provided an Interface Class, was given: "
+					+ writeInterface.getCanonicalName());
+		}
+		if (!writeInterface.isInterface())
+		{
+			throw new IllegalArgumentException(
+				"ContextFactory must be provided an Interface Class, was given: "
+					+ writeInterface.getCanonicalName());
+		}
+		processors = new ArrayList<>(processorList);
+		this.readInterface = Objects.requireNonNull(readInterface);
+		this.writeInterface = Objects.requireNonNull(writeInterface);
+		evaluateMethods();
+	}
+
+	private void evaluateMethods()
+	{
+		Method[] writeMethods = writeInterface.getMethods();
+		if (writeMethods.length == 0)
+		{
+			throw new IllegalArgumentException(
+				writeInterface.getSimpleName() + " had no methods");
+		}
+		Method[] readMethods = readInterface.getMethods();
+		if (readMethods.length == 0)
+		{
+			throw new IllegalArgumentException(
+				readInterface.getSimpleName() + " had no methods");
+		}
+		Set<Object> propertyNames = Collections.newSetFromMap(new CaseInsensitiveMap<>());
+		Set<Object> writeMethodNames =
+				Collections.newSetFromMap(new CaseInsensitiveMap<>());
+		List<Method> readMethodList = new ArrayList<>(Arrays.asList(readMethods));
+		METHODS: for (Method method : writeMethods)
+		{
+			String name = method.getName();
+			if (!writeMethodNames.add(name))
+			{
+				throw new IllegalArgumentException(
+					"Duplicate Write Method Name: " + name);
+			}
+			for (PropertyProcessor processor : processors)
+			{
+				if (processor.isProcessedMethod(method))
+				{
+					String property = processor.getPropertyName(name);
+					if (!propertyNames.add(property))
+					{
+						throw new IllegalArgumentException(
+							"Duplicate Property Name: " + property);
+					}
+					setMethods.add(name);
+					Method claimed = processor.claimMethod(method, readMethods);
+					readMethodList.remove(claimed);
+					getProcessors.put(claimed.getName(), processor);
+					continue METHODS;
+				}
+			}
+			throw new IllegalArgumentException(
+				"Unsure how to process Method Name: " + name);
+		}
+		if (!readMethodList.isEmpty())
+		{
+			throw new IllegalArgumentException("Had Leftover Methods: " + readMethodList);
+		}
+	}
+
+	@Override
+	public Class<W> getInterface()
+	{
+		return writeInterface;
+	}
+
+	@Override
+	public Object invoke(Object proxy, Method method, Object[] args) throws Throwable
+	{
+		String methodName = method.getName();
+		if (setMethods.contains(methodName))
+		{
+			addMethodCall(method, args);
+			//TODO Validate method's return type or pass to Processor??
+			return null;
+		}
+		PropertyProcessor processor = getProcessors.get(methodName);
+		ReadableHandler handler = processor.getInvocationHandler(methodName, args);
+		@SuppressWarnings("unchecked")
+		W extractor = (W) java.lang.reflect.Proxy.newProxyInstance(
+			writeInterface.getClassLoader(), new Class[]{writeInterface}, handler);
+		if (stagedMethodCalls != null)
+		{
+			for (Tuple<Method, Object[]> info : stagedMethodCalls)
+			{
+				info.getFirst().invoke(extractor, info.getSecond());
+			}
+		}
+		return handler.getResult();
+	}
+
+	private void addMethodCall(Method method, Object[] args)
+	{
+		if (stagedMethodCalls == null)
+		{
+			stagedMethodCalls = new ArrayList<>();
+		}
+		stagedMethodCalls.add(new Tuple<>(method, args));
+	}
+
+	@Override
+	public void applyTo(W target)
+	{
+		if (!writeInterface.isAssignableFrom(target.getClass()))
+		{
+			throw new IllegalArgumentException(
+				"This StagingProxy serves interface " + writeInterface.getCanonicalName()
+					+ " but the provided target did not implement that interface");
+		}
+		if (stagedMethodCalls == null)
+		{
+			return;
+		}
+		for (Tuple<Method, Object[]> methodInfo : stagedMethodCalls)
+		{
+			try
+			{
+				methodInfo.getFirst().invoke(target, methodInfo.getSecond());
+			}
+			catch (ReflectiveOperationException e)
+			{
+				throw new IllegalArgumentException(
+					"StagingProxy failure: ReflectiveOperationException: ", e);
+			}
+		}
+	}
+}

--- a/PCGen-base/code/src/test/pcgen/base/proxy/StagingProxyFactoryTest.java
+++ b/PCGen-base/code/src/test/pcgen/base/proxy/StagingProxyFactoryTest.java
@@ -1,0 +1,280 @@
+package pcgen.base.proxy;
+import static org.junit.Assert.fail;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import pcgen.base.proxy.ItemProcessor;
+import pcgen.base.proxy.ListProcessor;
+import pcgen.base.proxy.MapProcessor;
+import pcgen.base.proxy.StagingInfoFactory;
+
+public class StagingProxyFactoryTest
+{
+
+	private StagingInfoFactory factory = new StagingInfoFactory();
+
+	@Before
+	public void setUp()
+	{
+		factory.addProcessor(new ItemProcessor());
+		factory.addProcessor(new ListProcessor());
+		factory.addProcessor(new MapProcessor());
+	}
+
+	@Test
+	public void testInvalidClass()
+	{
+		try
+		{
+			factory.produceStaging(Object.class, SetItemOnly.class);
+			fail("factory should require an interface");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//Expected
+		}
+		try
+		{
+			factory.produceStaging(GetItemOnly.class, Object.class);
+			fail("factory should require an interface");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//Expected
+		}
+		try
+		{
+			factory.produceStaging(NoMethodInterface.class, SetItemOnly.class);
+			fail("factory should require an interface with methods");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//Expected
+		}
+		try
+		{
+			factory.produceStaging(GetListOnly.class, NoMethodInterface.class);
+			fail("factory should require an interface with methods");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//Expected
+		}
+		try
+		{
+			factory.produceStaging(SetItemOnly.class, SetItemOnly.class);
+			fail("Must have read methods on read interface");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//Expected
+		}
+		try
+		{
+			factory.produceStaging(GetListOnly.class, null);
+			fail("Can't take null item");
+		}
+		catch (IllegalArgumentException | NullPointerException e)
+		{
+			//Expected
+		}
+		try
+		{
+			factory.produceStaging(null, AddListOnly.class);
+			fail();
+		}
+		catch (IllegalArgumentException | NullPointerException e)
+		{
+			//Expected
+		}
+		try
+		{
+			factory.produceStaging(GetItemOnly.class, SetShouldBeVoid.class);
+			fail();
+		}
+		catch (IllegalArgumentException e)
+		{
+			//Expected
+		}
+		try
+		{
+			factory.produceStaging(GetListOnly.class, AddShouldBeVoid.class);
+			fail();
+		}
+		catch (IllegalArgumentException e)
+		{
+			//Expected
+		}
+		try
+		{
+			factory.produceStaging(GetMapOnly.class, PutShouldBeVoid.class);
+			fail();
+		}
+		catch (IllegalArgumentException e)
+		{
+			//Expected
+		}
+		try
+		{
+			factory.produceStaging(GetShouldHaveNoParams.class, SetItemOnly.class);
+			fail();
+		}
+		catch (IllegalArgumentException e)
+		{
+			//Expected
+		}
+		try
+		{
+			factory.produceStaging(GetItemOnly.class, SetItemShouldHaveOneParam.class);
+			fail();
+		}
+		catch (IllegalArgumentException e)
+		{
+			//Expected
+		}
+		try
+		{
+			factory.produceStaging(GetItemOnly.class, SetDupeName.class);
+			fail();
+		}
+		catch (IllegalArgumentException e)
+		{
+			//Expected
+		}
+		try
+		{
+			factory.produceStaging(GetNumber.class, SetItemOnly.class);
+			fail();
+		}
+		catch (IllegalArgumentException e)
+		{
+			//Expected
+		}
+		try
+		{
+			factory.produceStaging(GetItemOnly.class, LeftoverWrite.class);
+			fail();
+		}
+		catch (IllegalArgumentException e)
+		{
+			//Expected
+		}
+		try
+		{
+			factory.produceStaging(LeftoverRead.class, SetItemOnly.class);
+			fail();
+		}
+		catch (IllegalArgumentException e)
+		{
+			//Expected
+		}
+		try
+		{
+			factory.produceStaging(GetItemOnly.class, DupePropertyName.class);
+			fail();
+		}
+		catch (IllegalArgumentException e)
+		{
+			//Expected
+		}
+	}
+
+	@Test
+	public void test()
+	{
+		factory.produceStaging(GetItemOnly.class, SetItemOnly.class);
+		factory.produceStaging(GetListOnly.class, AddListOnly.class);
+		factory.produceStaging(GetMapOnly.class, PutMapOnly.class);
+	}
+
+	public interface NoMethodInterface
+	{
+
+	}
+
+	public interface SetItemOnly
+	{
+		public void setBasic(String s);
+	}
+
+	public interface GetItemOnly
+	{
+		public String getBasic();
+	}
+
+	public interface AddListOnly
+	{
+		public void addBasic(String s);
+	}
+
+	public interface GetListOnly
+	{
+		public String[] getBasicArray();
+	}
+
+	public interface PutMapOnly
+	{
+		public void put(String s, Object value);
+	}
+
+	public interface GetMapOnly
+	{
+		public Object get(String s);
+	}
+
+	public interface SetShouldBeVoid
+	{
+		public boolean setBasic(String s);
+	}
+
+	public interface GetShouldHaveNoParams
+	{
+		public String getBasic(String s);
+	}
+
+	public interface GetNumber
+	{
+		public Number getBasic();
+	}
+
+	public interface SetItemShouldHaveOneParam
+	{
+		public void setBasic(String name, String s);
+	}
+
+	public interface AddShouldBeVoid
+	{
+		public boolean addBasic(String s);
+	}
+
+	public interface PutShouldBeVoid
+	{
+		public boolean put(String s, Object value);
+	}
+
+	public interface SetDupeName
+	{
+		public void setBasic(String s);
+		public void setBasic(Number n);
+	}
+
+	public interface LeftoverWrite
+	{
+		public void setBasic(String s);
+		public void doBasic(Number n);
+	}
+
+	public interface LeftoverRead
+	{
+		public String getBasic();
+		public Number[] getBasicStuff();
+	}
+
+	public interface DupePropertyName
+	{
+		public void setBasic(String s);
+		public void addBasic(Number n);
+	}
+
+}


### PR DESCRIPTION
This library item is designed to produce a proxy to be used for
transactions.  This will allow us to do a few changes in the main PCGen
repository:

(1) We will be able to enable tokens that operate on interfaces.  This
will allow us to have one shared token for multiple classes.  This will
be important for MODIFY/MODIFYOTHER which we want to share with Dynamic
objects, without having Dynamic objects take on the burden of being a
CDOMObject.

(2) Other tokens that duplicate today could be consolidated.

(3) The complex transaction system within the ObjectContext could be
eliminated, as the StagingProxy system here performs the same function
without the sprawl of boilerplate code.