### PR TITLE
Allow Write Interface to extend the Read Interface when a Proxy is used

### DIFF
--- a/PCGen-base/code/src/java/pcgen/base/proxy/StagingProxy.java
+++ b/PCGen-base/code/src/java/pcgen/base/proxy/StagingProxy.java
@@ -140,6 +140,12 @@ class StagingProxy<R, W> implements InvocationHandler, Staging<W>
 			throw new IllegalArgumentException(
 				readInterface.getSimpleName() + " had no methods");
 		}
+		processMethods(readMethods, writeMethods);
+	}
+
+	private void processMethods(Method[] readMethods, Method[] writeMethods)
+	{
+		List<Method> readMethodList = new ArrayList<>(Arrays.asList(readMethods));
 		Set<Object> propertyNames = Collections.newSetFromMap(new CaseInsensitiveMap<>());
 		Set<Object> writeMethodNames =
 				Collections.newSetFromMap(new CaseInsensitiveMap<>());
@@ -147,7 +153,6 @@ class StagingProxy<R, W> implements InvocationHandler, Staging<W>
 				Collections.newSetFromMap(new CaseInsensitiveMap<>());
 		Set<Object> consumedMethodNames =
 				Collections.newSetFromMap(new CaseInsensitiveMap<>());
-		List<Method> readMethodList = new ArrayList<>(Arrays.asList(readMethods));
 		METHODS: for (Method method : writeMethods)
 		{
 			String name = method.getName();

--- a/PCGen-base/code/src/java/pcgen/base/proxy/StagingProxy.java
+++ b/PCGen-base/code/src/java/pcgen/base/proxy/StagingProxy.java
@@ -143,6 +143,10 @@ class StagingProxy<R, W> implements InvocationHandler, Staging<W>
 		Set<Object> propertyNames = Collections.newSetFromMap(new CaseInsensitiveMap<>());
 		Set<Object> writeMethodNames =
 				Collections.newSetFromMap(new CaseInsensitiveMap<>());
+		Set<Object> unusedMethodNames =
+				Collections.newSetFromMap(new CaseInsensitiveMap<>());
+		Set<Object> consumedMethodNames =
+				Collections.newSetFromMap(new CaseInsensitiveMap<>());
 		List<Method> readMethodList = new ArrayList<>(Arrays.asList(readMethods));
 		METHODS: for (Method method : writeMethods)
 		{
@@ -165,12 +169,18 @@ class StagingProxy<R, W> implements InvocationHandler, Staging<W>
 					setMethods.add(name);
 					Method claimed = processor.claimMethod(method, readMethods);
 					readMethodList.remove(claimed);
+					consumedMethodNames.add(claimed.getName());
 					getProcessors.put(claimed.getName(), processor);
 					continue METHODS;
 				}
 			}
+			unusedMethodNames.add(name);
+		}
+		unusedMethodNames.removeAll(consumedMethodNames);
+		if (!unusedMethodNames.isEmpty())
+		{
 			throw new IllegalArgumentException(
-				"Unsure how to process Method Name: " + name);
+				"Unable to process method names: " + unusedMethodNames);
 		}
 		if (!readMethodList.isEmpty())
 		{

--- a/PCGen-base/code/src/test/pcgen/base/proxy/StagingProxyFactoryTest.java
+++ b/PCGen-base/code/src/test/pcgen/base/proxy/StagingProxyFactoryTest.java
@@ -186,6 +186,9 @@ public class StagingProxyFactoryTest
 		factory.produceStaging(GetItemOnly.class, SetItemOnly.class);
 		factory.produceStaging(GetListOnly.class, AddListOnly.class);
 		factory.produceStaging(GetMapOnly.class, PutMapOnly.class);
+		factory.produceStaging(GetItemOnly.class, SetItem.class);
+		factory.produceStaging(GetListOnly.class, AddList.class);
+		factory.produceStaging(GetMapOnly.class, PutMap.class);
 	}
 
 	public interface NoMethodInterface
@@ -277,4 +280,18 @@ public class StagingProxyFactoryTest
 		public void addBasic(Number n);
 	}
 
+	public interface SetItem extends GetItemOnly
+	{
+		public void setBasic(String s);
+	}
+
+	public interface AddList extends GetListOnly
+	{
+		public void addBasic(String s);
+	}
+
+	public interface PutMap extends GetMapOnly
+	{
+		public void put(String s, Object value);
+	}
 }


### PR DESCRIPTION

Currently the proxy system as defined here requires the read and write interfaces to be completely separate.  In practice, it is useful to have the write interface extend the read interface, so this is more tolerant and allows that situation.
