### PR TITLE
[build] life suppport for pcgen-base

### DIFF
--- a/PCGen-base/build.gradle
+++ b/PCGen-base/build.gradle
@@ -17,6 +17,7 @@ plugins {
 	id 'pmd'
 	id 'jdepend'
     id "com.github.spotbugs" version '1.6.1'
+    id 'com.github.ben-manes.versions' version '0.20.0'
 }
 
 group = 'net.sourceforge.pcgen'

--- a/PCGen-base/build.gradle
+++ b/PCGen-base/build.gradle
@@ -16,7 +16,7 @@ plugins {
 	id 'checkstyle'
 	id 'pmd'
 	id 'jdepend'
-    id "com.github.spotbugs" version '1.6.1'
+    id "com.github.spotbugs" version '1.6.5'
     id 'com.github.ben-manes.versions' version '0.20.0'
 }
 

--- a/PCGen-base/gradle/reporting.gradle
+++ b/PCGen-base/gradle/reporting.gradle
@@ -37,8 +37,4 @@ jdepend {
 	sourceSets = []
 }
 
-task wrapper(type: Wrapper) {
-	gradleVersion = '4.4.1'
-}
-
 task allReports { dependsOn = ['checkstyleMain', 'pmdMain', 'spotbugsMain', 'jdependMain'] }

--- a/PCGen-base/gradle/wrapper/gradle-wrapper.properties
+++ b/PCGen-base/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip


### PR DESCRIPTION
Allow pcgen-base to compile with a Java 11 runtime