### PR TITLE
Clean up Java 11 items

### DIFF
--- a/PCGen-base/code/src/java/pcgen/base/format/ArrayFormatManager.java
+++ b/PCGen-base/code/src/java/pcgen/base/format/ArrayFormatManager.java
@@ -108,7 +108,6 @@ public class ArrayFormatManager<T> implements FormatManager<T[]>
 		Class<T> managedClass = componentManager.getManagedClass();
 		if (componentManager instanceof DispatchingFormatManager)
 		{
-			@SuppressWarnings("unchecked")
 			DispatchingFormatManager<T> dfm =
 					(DispatchingFormatManager<T>) componentManager;
 			String[] groups = splitInstructions(instructions, groupSeparator);
@@ -142,7 +141,6 @@ public class ArrayFormatManager<T> implements FormatManager<T[]>
 		Indirect<T>[] array = null;
 		if (componentManager instanceof DispatchingFormatManager)
 		{
-			@SuppressWarnings("unchecked")
 			DispatchingFormatManager<T> dfm =
 					(DispatchingFormatManager<T>) componentManager;
 			String[] groups = splitInstructions(instructions, groupSeparator);
@@ -229,7 +227,6 @@ public class ArrayFormatManager<T> implements FormatManager<T[]>
 	{
 		if (componentManager instanceof DispatchingFormatManager)
 		{
-			@SuppressWarnings("unchecked")
 			DispatchingFormatManager<T> dfm =
 					(DispatchingFormatManager<T>) componentManager;
 			Stream<Tuple<String, String>> unconverted =

--- a/PCGen-base/code/src/java/pcgen/base/util/ArrayUtilities.java
+++ b/PCGen-base/code/src/java/pcgen/base/util/ArrayUtilities.java
@@ -232,7 +232,6 @@ public final class ArrayUtilities
 	 * @param <T>
 	 *            The type of the array and the object to be added to the array
 	 */
-	@SuppressWarnings("unchecked")
 	public static <T> T[] prependOnCopy(T object, T[] array)
 	{
 		return addOnCopy(array, 0, object);
@@ -252,7 +251,6 @@ public final class ArrayUtilities
 	 * @param <T>
 	 *            The type of the array and the object to be added to the array
 	 */
-	@SuppressWarnings("unchecked")
 	public static <T> T[] addOnCopy(T[] array, T object)
 	{
 		return addOnCopy(array, (array == null) ? 0 : array.length, object);


### PR DESCRIPTION
Remove unused warning suppressions based two that were unnecessary and three that are no longer necessary based on Java 11 behavior
