### PR TITLE
Add Optional Format

### DIFF
--- a/PCGen-base/code/src/java/pcgen/base/format/OptionalFormatManager.java
+++ b/PCGen-base/code/src/java/pcgen/base/format/OptionalFormatManager.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2019 Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This program is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 51 Franklin Street,
+ * Fifth Floor, Boston, MA 02110-1301, USA
+ */
+package pcgen.base.format;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import pcgen.base.util.BasicIndirect;
+import pcgen.base.util.FormatManager;
+import pcgen.base.util.Indirect;
+import pcgen.base.util.ValueStore;
+
+/**
+ * An OptionalFormatManager wraps an underlying FormatManager to produce Optional of an
+ * object.
+ * 
+ * @param <T>
+ *            The format (class) of object contained within the Optional that this
+ *            OptionalFormatManager manages.
+ */
+public class OptionalFormatManager<T> implements FormatManager<Optional<T>>
+{
+
+	/**
+	 * The FormatManager representing the object potentially contained within the
+	 * Optional.
+	 */
+	private final FormatManager<T> componentManager;
+
+	/**
+	 * Constructs a new OptionalFormatManager with the given underlying component
+	 * FormatManager.
+	 * 
+	 * @param underlying
+	 *            The FormatManager representing objects potentially contained within the
+	 *            Optional
+	 */
+	public OptionalFormatManager(FormatManager<T> underlying)
+	{
+		componentManager = Objects.requireNonNull(underlying);
+	}
+
+	/**
+	 * Converts the instructions into an Optional object.
+	 */
+	@Override
+	public Optional<T> convert(String instructions)
+	{
+		if ((instructions == null) || instructions.isEmpty())
+		{
+			return Optional.empty();
+		}
+		return Optional.of(componentManager.convert(instructions));
+	}
+
+	/**
+	 * Converts the instructions into an Indirect array of objects. The objects referred
+	 * to in the instructions should be separated by the separator provided at
+	 * construction of this ArrayFormatManager.
+	 */
+	@Override
+	public Indirect<Optional<T>> convertIndirect(String instructions)
+	{
+		Indirect<T> indirect = componentManager.convertIndirect(instructions);
+		if ((instructions == null) || instructions.isEmpty())
+		{
+			return new BasicIndirect<>(this, Optional.empty());
+		}
+		return new OptionalIndirect(indirect);
+	}
+
+	@Override
+	public Optional<FormatManager<?>> getComponentManager()
+	{
+		return Optional.empty();
+	}
+
+	@Override
+	public String getIdentifierType()
+	{
+		return "OPTIONAL[" + componentManager.getIdentifierType() + "]";
+	}
+
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	@Override
+	public Class<Optional<T>> getManagedClass()
+	{
+		return (Class) Optional.class;
+	}
+
+	/**
+	 * OptionalIndirect is a wrapper that converts an Indirect object into an Indirect of
+	 * an Optional object.
+	 */
+	private final class OptionalIndirect implements Indirect<Optional<T>>
+	{
+		/**
+		 * The underlying Indirect object used to resolve this OptionalIndirect.
+		 */
+		private final Indirect<T> underlying;
+
+		/**
+		 * Constructs a new OptionalIndirect with the given underlying underlying Indirect
+		 * containing the objects for this OptionalIndirect.
+		 * 
+		 * @param underlying
+		 *            The underlying Indirect with the objects contained in this
+		 *            OptionalIndirect
+		 */
+		private OptionalIndirect(Indirect<T> underlying)
+		{
+			this.underlying = underlying;
+		}
+
+		@Override
+		public Optional<T> get()
+		{
+			return Optional.of(underlying.get());
+		}
+
+		@Override
+		public String getUnconverted()
+		{
+			return underlying.getUnconverted();
+		}
+	}
+
+	@Override
+	public String unconvert(Optional<T> optional)
+	{
+		return optional.map(componentManager::unconvert).orElse("");
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return componentManager.hashCode() + 1;
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		return (o instanceof OptionalFormatManager) && componentManager
+			.equals(((OptionalFormatManager<?>) o).componentManager);
+	}
+
+	@Override
+	public boolean isDirect()
+	{
+		return componentManager.isDirect();
+	}
+
+	@Override
+	public Optional<T> initializeFrom(ValueStore valueStore)
+	{
+		return Optional.empty();
+	}
+}

--- a/PCGen-base/code/src/java/pcgen/base/format/OptionalFormatManager.java
+++ b/PCGen-base/code/src/java/pcgen/base/format/OptionalFormatManager.java
@@ -74,18 +74,18 @@ public class OptionalFormatManager<T> implements FormatManager<Optional<T>>
 	@Override
 	public Indirect<Optional<T>> convertIndirect(String instructions)
 	{
-		Indirect<T> indirect = componentManager.convertIndirect(instructions);
 		if ((instructions == null) || instructions.isEmpty())
 		{
 			return new BasicIndirect<>(this, Optional.empty());
 		}
+		Indirect<T> indirect = componentManager.convertIndirect(instructions);
 		return new OptionalIndirect(indirect);
 	}
 
 	@Override
 	public Optional<FormatManager<?>> getComponentManager()
 	{
-		return Optional.empty();
+		return Optional.of(componentManager);
 	}
 
 	@Override

--- a/PCGen-base/code/src/java/pcgen/base/formatmanager/FormatUtilities.java
+++ b/PCGen-base/code/src/java/pcgen/base/formatmanager/FormatUtilities.java
@@ -106,6 +106,7 @@ public final class FormatUtilities
 	{
 		library.addFormatManagerBuilder(new CompoundFormatFactory(',', '|'));
 		library.addFormatManagerBuilder(new ArrayFormatFactory('\n', ','));
+		library.addFormatManagerBuilder(new OptionalFormatFactory());
 	}
 
 	/**

--- a/PCGen-base/code/src/java/pcgen/base/formatmanager/OptionalFormatFactory.java
+++ b/PCGen-base/code/src/java/pcgen/base/formatmanager/OptionalFormatFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.formatmanager;
+
+import pcgen.base.format.OptionalFormatManager;
+import pcgen.base.util.FormatManager;
+
+/**
+ * An OptionalFormatFactory builds a FormatManager supporting Arrays from the name of the
+ * format of the component of the Array
+ */
+public class OptionalFormatFactory implements FormatManagerFactory
+{
+
+	@Override
+	public FormatManager<?> build(String subFormatName,
+		FormatManagerLibrary library)
+	{
+		if (subFormatName == null)
+		{
+			throw new IllegalArgumentException(
+				"Cannot build OPTIONAL with no subformat");
+		}
+		return new OptionalFormatManager<>(
+			library.getFormatManager(subFormatName));
+	}
+
+	@Override
+	public String getBuilderBaseFormat()
+	{
+		return "OPTIONAL";
+	}
+
+}

--- a/PCGen-base/code/src/test/pcgen/base/format/OptionalFormatManagerTest.java
+++ b/PCGen-base/code/src/test/pcgen/base/format/OptionalFormatManagerTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2014 Tom Parker <thpr@users.sourceforge.net> This program is free
+ * software; you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 51 Franklin Street,
+ * Fifth Floor, Boston, MA 02110-1301, USA
+ */
+package pcgen.base.format;
+
+import java.util.Optional;
+
+import junit.framework.TestCase;
+import pcgen.base.util.FormatManager;
+import pcgen.base.util.Indirect;
+import pcgen.base.util.SimpleValueStore;
+
+/**
+ * Test the OptionalFormatManager class
+ */
+public class OptionalFormatManagerTest extends TestCase
+{
+	private OptionalFormatManager<Number> manager =
+			new OptionalFormatManager<>(new NumberManager());
+
+	@SuppressWarnings("unused")
+	public void testConstructor()
+	{
+		try
+		{
+			new OptionalFormatManager<>(null);
+			fail("null value should fail");
+		}
+		catch (IllegalArgumentException | NullPointerException e)
+		{
+			//expected
+		}
+	}
+
+	public void testConvertFailNotNumeric()
+	{
+		try
+		{
+			manager.convert("SomeString");
+			fail("null value should fail");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//expected
+		}
+	}
+
+	public void testUnconvertFailNull()
+	{
+		try
+		{
+			manager.unconvert(null);
+			fail("null value should fail");
+		}
+		catch (NullPointerException | IllegalArgumentException e)
+		{
+			//expected
+		}
+	}
+
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	public void testUnconvertFailObject()
+	{
+		try
+		{
+			//Yes generics are being violated in order to do this test
+			FormatManager formatManager = manager;
+			formatManager.unconvert(new Object());
+			fail("Object should fail");
+		}
+		catch (ClassCastException | IllegalArgumentException e)
+		{
+			//expected
+		}
+	}
+
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	public void testUnconvertFailUnderlying()
+	{
+		try
+		{
+			//Yes generics are being violated in order to do this test
+			FormatManager formatManager = manager;
+			formatManager.unconvert(1);
+			fail("Integer should fail");
+		}
+		catch (ClassCastException | IllegalArgumentException e)
+		{
+			//expected
+		}
+	}
+
+	public void testConvertIndirectFailNotNumeric()
+	{
+		try
+		{
+			manager.convertIndirect("SomeString");
+			fail("null value should fail");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//expected
+		}
+	}
+
+	public void testConvertEmpty()
+	{
+		assertEquals(Optional.empty(), manager.convert(""));
+		assertEquals(Optional.empty(), manager.convert(null));
+	}
+
+	public void testConvertIndirectEmpty()
+	{
+		assertEquals(Optional.empty(), manager.convertIndirect("").get());
+		assertEquals(Optional.empty(), manager.convertIndirect(null).get());
+	}
+
+	public void testConvert()
+	{
+		assertEquals(Optional.of(1), manager.convert("1"));
+		assertEquals(Optional.of(-3), manager.convert("-3"));
+		assertEquals(Optional.of(1.4), manager.convert("1.4"));
+	}
+
+	public void testUnconvert()
+	{
+		assertEquals("", manager.unconvert(Optional.empty()));
+		assertEquals("1", manager.unconvert(Optional.of(1)));
+		assertEquals("-3", manager.unconvert(Optional.of(-3)));
+		assertEquals("1.4", manager.unconvert(Optional.of(1.4)));
+	}
+
+	public void testConvertIndirect()
+	{
+		assertEquals(Optional.of(1), manager.convertIndirect("1").get());
+		assertEquals(Optional.of(-3), manager.convertIndirect("-3").get());
+		assertEquals(Optional.of(1.4), manager.convertIndirect("1.4").get());
+
+		assertEquals("1", manager.convertIndirect("1").getUnconverted());
+		assertEquals("-3", manager.convertIndirect("-3").getUnconverted());
+		assertEquals("1.4", manager.convertIndirect("1.4").getUnconverted());
+	}
+
+	public void testGetIdentifier()
+	{
+		assertEquals("OPTIONAL[NUMBER]", manager.getIdentifierType());
+	}
+
+	public void testManagedClass()
+	{
+		assertSame(Optional.class, manager.getManagedClass());
+	}
+
+	public void testHashCodeEquals()
+	{
+		assertEquals(
+			new OptionalFormatManager<>(new NumberManager()).hashCode(),
+			manager.hashCode());
+		//different underlying
+		assertFalse(
+			manager.equals(new OptionalFormatManager<>(new BooleanManager())));
+	}
+
+	public void testGetComponent()
+	{
+		assertEquals(new NumberManager(), manager.getComponentManager().get());
+	}
+
+	public void testIsDirect()
+	{
+		assertTrue(manager.isDirect());
+		assertTrue(
+			new OptionalFormatManager<>(new BooleanManager()).isDirect());
+		assertTrue(new OptionalFormatManager<>(new StringManager()).isDirect());
+		assertFalse(new OptionalFormatManager<>(new FormatManager<Object>()
+		{
+
+			@Override
+			public Object convert(String inputStr)
+			{
+				return null;
+			}
+
+			@Override
+			public Indirect<Object> convertIndirect(String inputStr)
+			{
+				return null;
+			}
+
+			@Override
+			public boolean isDirect()
+			{
+				return false;
+			}
+
+			@Override
+			public String unconvert(Object obj)
+			{
+				return null;
+			}
+
+			@Override
+			public Class<Object> getManagedClass()
+			{
+				return Object.class;
+			}
+
+			@Override
+			public String getIdentifierType()
+			{
+				return null;
+			}
+
+			@Override
+			public Optional<FormatManager<?>> getComponentManager()
+			{
+				return Optional.empty();
+			}
+
+		}).isDirect());
+	}
+
+	public void testInitializeFrom()
+	{
+		assertEquals(Optional.empty(),
+			manager.initializeFrom(new SimpleValueStore()));
+	}
+
+}

--- a/PCGen-base/code/src/test/pcgen/base/formatmanager/OptionalFormatFactoryTest.java
+++ b/PCGen-base/code/src/test/pcgen/base/formatmanager/OptionalFormatFactoryTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2014 Tom Parker <thpr@users.sourceforge.net> This program is free
+ * software; you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 51 Franklin Street,
+ * Fifth Floor, Boston, MA 02110-1301, USA
+ */
+package pcgen.base.formatmanager;
+
+import java.util.Optional;
+
+import junit.framework.TestCase;
+import pcgen.base.format.NumberManager;
+import pcgen.base.format.StringManager;
+import pcgen.base.util.FormatManager;
+
+/**
+ * Test the OptionalFormatFactory class
+ */
+public class OptionalFormatFactoryTest extends TestCase
+{
+
+	private SimpleFormatManagerLibrary library;
+	private OptionalFormatFactory factory;
+
+	@Override
+	protected void setUp() throws Exception
+	{
+		super.setUp();
+		library = new SimpleFormatManagerLibrary();
+		FormatUtilities.loadDefaultFormats(library);
+		factory = new OptionalFormatFactory();
+		library.addFormatManagerBuilder(factory);
+	}
+
+	public void testFailBadSubFormat()
+	{
+		try
+		{
+			factory.build("NUM", library);
+			fail("bad sub form should fail");
+		}
+		catch (NullPointerException | IllegalArgumentException e)
+		{
+			//expected
+		}
+	}
+
+	public void testFailNullSubFormat()
+	{
+		try
+		{
+			factory.build(null, library);
+			fail("null sub form should fail");
+		}
+		catch (IllegalArgumentException | NullPointerException e)
+		{
+			//expected
+		}
+	}
+
+	public void testConvert()
+	{
+		@SuppressWarnings("unchecked")
+		FormatManager<Optional<Number>> manager =
+				(FormatManager<Optional<Number>>) factory.build("NUMBER",
+					library);
+		assertEquals(Optional.empty(), manager.convert(null));
+		assertEquals(Optional.empty(), manager.convert(""));
+		assertEquals(1, manager.convert("1").get());
+		assertEquals(-3, manager.convert("-3").get());
+		assertEquals(1.4, manager.convert("1.4").get());
+	}
+
+	public void testGetIdentifier()
+	{
+		FormatManager<?> manager = factory.build("NUMBER", library);
+		assertEquals("OPTIONAL[NUMBER]", manager.getIdentifierType());
+		manager = factory.build("STRING", library);
+		assertEquals("OPTIONAL[STRING]", manager.getIdentifierType());
+	}
+
+	public void testManagedClass()
+	{
+		FormatManager<?> manager = factory.build("NUMBER", library);
+		assertEquals(Optional.class, manager.getManagedClass());
+		assertTrue(manager.getComponentManager().isPresent());
+		assertEquals(new NumberManager(), manager.getComponentManager().get());
+		manager = factory.build("STRING", library);
+		assertEquals(Optional.class, manager.getManagedClass());
+		assertTrue(manager.getComponentManager().isPresent());
+		assertEquals(new StringManager(), manager.getComponentManager().get());
+	}
+
+	public void testGetComponent()
+	{
+		FormatManager<?> manager = factory.build("NUMBER", library);
+		assertEquals(new NumberManager(), manager.getComponentManager().get());
+		manager = factory.build("STRING", library);
+		assertEquals(new StringManager(), manager.getComponentManager().get());
+	}
+
+}


### PR DESCRIPTION
Adds "OPTIONAL[x]" as a legal format in the formula system.
Usable for various items that don't need to be set (for example, certain variables can exist on a PC but override the global settings, this allows indicating that those items are not set on the PC)