### PR TITLE
Ensure NamedIndirect constructors are not ambiguous

### DIFF
--- a/PCGen-base/code/src/java/pcgen/base/format/compound/CompoundFormatManager.java
+++ b/PCGen-base/code/src/java/pcgen/base/format/compound/CompoundFormatManager.java
@@ -416,6 +416,6 @@ public class CompoundFormatManager<T> implements DispatchingFormatManager<Compou
 		String name, FormatManager<S> secondaryManager)
 	{
 		S secondaryValue = secondaryManager.initializeFrom(valueStore);
-		return new NamedIndirect<>(name, secondaryManager, secondaryValue);
+		return new NamedIndirect<>(name, secondaryValue, secondaryManager);
 	}
 }

--- a/PCGen-base/code/src/java/pcgen/base/format/compound/DirectCompound.java
+++ b/PCGen-base/code/src/java/pcgen/base/format/compound/DirectCompound.java
@@ -24,7 +24,7 @@ import pcgen.base.util.FormatManager;
 /**
  * DirectCompound is an AbstractCompound for direct types (Number.class)
  */
-class DirectCompound extends AbstractCompound
+public class DirectCompound extends AbstractCompound
 {
 
 	/**
@@ -41,7 +41,7 @@ class DirectCompound extends AbstractCompound
 	 * @param fmtManager
 	 *            The FormatManager for this DirectCompound
 	 */
-	DirectCompound(Object primary, FormatManager<Compound> fmtManager)
+	public DirectCompound(Object primary, FormatManager<Compound> fmtManager)
 	{
 		super(fmtManager);
 		object = Objects.requireNonNull(primary);

--- a/PCGen-base/code/src/java/pcgen/base/util/NamedIndirect.java
+++ b/PCGen-base/code/src/java/pcgen/base/util/NamedIndirect.java
@@ -47,12 +47,12 @@ public class NamedIndirect<T>
 	 * 
 	 * @param name
 	 *            The name of this NamedIndirect
-	 * @param manager
-	 *            The FormatManager used to unconvert the value
 	 * @param object
 	 *            The value of this NamedIndirect
+	 * @param manager
+	 *            The FormatManager used to unconvert the value
 	 */
-	public NamedIndirect(String name, FormatManager<T> manager, T object)
+	public NamedIndirect(String name, T object, FormatManager<T> manager)
 	{
 		this.name = Objects.requireNonNull(name);
 		this.object = new BasicIndirect<>(manager, object);


### PR DESCRIPTION
T==String was ambiguous
Also changes visibility on DirectCompount (needed for later tests)