### PR TITLE
[build] bump gradle to 6.9.1

### DIFF
--- a/PCGen-base/build.gradle
+++ b/PCGen-base/build.gradle
@@ -9,7 +9,6 @@
  */
 
 plugins {
-    id 'com.gradle.build-scan' version '3.6.1'
     id 'java'
     id 'eclipse'
     id "jacoco"

--- a/PCGen-base/gradle/reporting.gradle
+++ b/PCGen-base/gradle/reporting.gradle
@@ -32,9 +32,4 @@ spotbugs {
     toolVersion = "3.1.8"
 }
 
-buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service';
-        termsOfServiceAgree = 'yes'
-}
-
 task allReports { dependsOn = ['checkstyleMain', 'pmdMain', 'spotbugsMain'] }

--- a/PCGen-base/gradle/wrapper/gradle-wrapper.properties
+++ b/PCGen-base/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
this is a preparatory change for bumping to 7.x
this requires removing the build scan plugin which no longer works with
modern gradle